### PR TITLE
Support for forked permit2 contract that supports batch claim

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,6 +1,7 @@
-import { Hono } from 'hono';
 import { createClient } from '@supabase/supabase-js';
 import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 
 type PermitClaim = {
   nonce: string;
@@ -10,7 +11,7 @@ type PermitClaim = {
 };
 
 const app = new Hono();
-
+app.use("*", cors());
 
 // Initialize Supabase client with environment validation
 const requiredEnvVars = {
@@ -33,9 +34,9 @@ const supabase = createClient(
 // API endpoint for recording claims
 app.post('/api/permits/record-claim', async (c: Context) => {
   try {
-    const { nonce, transactionHash } = await c.req.json();
+    const { signature, transactionHash } = await c.req.json();
 
-    if (!nonce || !transactionHash) {
+    if (!signature || !transactionHash) {
       return c.json({ error: 'Missing required fields' }, 400);
     }
 
@@ -43,10 +44,9 @@ app.post('/api/permits/record-claim', async (c: Context) => {
       .from('permits')
       .update({
         transaction: transactionHash
-        // The claimed_at column doesn't exist in the permits table
-        // Using only the transaction column as requested
       })
-      .eq('nonce', nonce);
+      .eq('signature', signature)
+      .is('transaction', null);
 
     if (error) throw error;
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@supabase/supabase-js": "^2.49.4",
         "@tanstack/react-query": "^5.70.0",
         "@ubiquity-dao/permit2-rpc-client": "0.1.2",
+        "@uniswap/permit2-sdk": "^1.3.1",
         "@wagmi/connectors": "^5.7.11",
         "hono": "^4.3.4",
         "react": "^19.0.0",
@@ -457,6 +458,8 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.29.0", "", { "dependencies": { "@typescript-eslint/types": "8.29.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg=="],
 
     "@ubiquity-dao/permit2-rpc-client": ["@ubiquity-dao/permit2-rpc-client@0.1.2", "", {}, "sha512-4Hxjssybcr2kcSVjrMHEsjfLRG/ZaWkgoLheymaZYJzhjuKfJ9g2I4UVfzMNqnv5bpmLbdsWg+PtKvJjO+sogA=="],
+
+    "@uniswap/permit2-sdk": ["@uniswap/permit2-sdk@1.3.1", "", { "dependencies": { "ethers": "^5.7.0", "tiny-invariant": "^1.1.0" } }, "sha512-Eq2by4zVEVSZL3PJ1Yuf5+AZ/yE1GOuksWzPXPoxr5WRm3hqh34jKEqtyTImHqwuPrdILG8i02xJmgGLTH1QfA=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.4", "", { "dependencies": { "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug=="],
 
@@ -1323,6 +1326,8 @@
     "thread-stream": ["thread-stream@0.15.2", "", { "dependencies": { "real-require": "^0.1.0" } }, "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA=="],
 
     "timers-browserify": ["timers-browserify@2.0.12", "", { "dependencies": { "setimmediate": "^1.0.4" } }, "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@supabase/supabase-js": "^2.49.4",
     "@tanstack/react-query": "^5.70.0",
     "@ubiquity-dao/permit2-rpc-client": "0.1.2",
+    "@uniswap/permit2-sdk": "^1.3.1",
     "@wagmi/connectors": "^5.7.11",
     "hono": "^4.3.4",
     "react": "^19.0.0",

--- a/frontend/src/components/dashboard-page.tsx
+++ b/frontend/src/components/dashboard-page.tsx
@@ -1,16 +1,15 @@
-import { useEffect, useState, useMemo, useCallback } from "react";
-import { useAccount, useDisconnect } from "wagmi";
-import { Address } from "viem";
-import { hasRequiredFields } from "../utils/permit-utils.ts";
-import { PermitsTable } from "./permits-table.tsx";
-import { usePermitData } from "../hooks/use-permit-data.ts";
-import { usePermitClaiming } from "../hooks/use-permit-claiming.ts";
-import { LogoSpan } from "./login-page.tsx";
-import { PreferredTokenSelectorButton } from "./preferred-token-selector-button.tsx";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Address, formatUnits } from "viem";
+import { useAccount, useDisconnect, usePublicClient, useWalletClient } from "wagmi";
+import { NEW_PERMIT2_ADDRESS } from "../constants/config.ts";
 import { getTokenInfo } from "../constants/supported-reward-tokens.ts";
-import { formatUnits } from "viem";
-import { usePublicClient, useWalletClient } from "wagmi";
+import { usePermitClaiming } from "../hooks/use-permit-claiming.ts";
+import { usePermitData } from "../hooks/use-permit-data.ts";
+import { hasRequiredFields } from "../utils/permit-utils.ts";
 import { ICONS } from "./iconography.tsx";
+import { LogoSpan } from "./login-page.tsx";
+import { PermitsTable } from "./permits-table.tsx";
+import { PreferredTokenSelectorButton } from "./preferred-token-selector-button.tsx";
 
 export function DashboardPage() {
   // UI State
@@ -48,6 +47,7 @@ export function DashboardPage() {
     const filteredPermits = permits.filter(
       (p) =>
         p.networkId === chain?.id &&
+        p.permit2Address === NEW_PERMIT2_ADDRESS &&
         p.type === "erc20-permit" &&
         p.status !== "Claimed" &&
         p.claimStatus !== "Success" &&
@@ -98,17 +98,25 @@ export function DashboardPage() {
     }
 
     let totalEstimatedValueInWei = 0n;
-    const permitsToConsider = permits.filter(p => claimablePermits.some(cp => cp.nonce === p.nonce && cp.networkId === p.networkId)); // Use permits that passed claimable filter
+    const permitsToConsider = permits.filter((p) => claimablePermits.some((cp) => cp.nonce === p.nonce && cp.networkId === p.networkId)); // Use permits that passed claimable filter
 
-    permitsToConsider.forEach(permit => {
+    permitsToConsider.forEach((permit) => {
       if (permit.tokenAddress?.toLowerCase() === preferredRewardTokenAddress.toLowerCase()) {
         // Add original amount if it's already the preferred token
         if (permit.amount) {
-          try { totalEstimatedValueInWei += BigInt(permit.amount); } catch (e) { console.error(`Error parsing original amount for estimatedTotalValue calc: ${permit.amount}`, e); }
+          try {
+            totalEstimatedValueInWei += BigInt(permit.amount);
+          } catch (e) {
+            console.error(`Error parsing original amount for estimatedTotalValue calc: ${permit.amount}`, e);
+          }
         }
       } else if (permit.estimatedAmountOut) {
         // Add estimated amount if quote exists
-         try { totalEstimatedValueInWei += BigInt(permit.estimatedAmountOut); } catch (e) { console.error(`Error parsing estimated amount for estimatedTotalValue calc: ${permit.estimatedAmountOut}`, e); }
+        try {
+          totalEstimatedValueInWei += BigInt(permit.estimatedAmountOut);
+        } catch (e) {
+          console.error(`Error parsing estimated amount for estimatedTotalValue calc: ${permit.estimatedAmountOut}`, e);
+        }
       }
       // Ignore permits with quote errors or no quote needed/available
     });
@@ -130,7 +138,8 @@ export function DashboardPage() {
 
   const {
     handleClaimPermit,
-    handleClaimAllBatchRpc,
+    handleClaimBatch,
+    handleClaimSequential,
     isClaimingSequentially,
     sequentialClaimError,
     // Removed isClaimConfirming since we now use per-permit claimStatus
@@ -160,7 +169,6 @@ export function DashboardPage() {
     // TODO: Trigger quote fetching/recalculation based on the new preference
     console.log("DashboardPage received preference change:", selectedAddress);
   }, []);
-
 
   // --- Effects ---
 
@@ -200,7 +208,7 @@ export function DashboardPage() {
             {/* Claim All Button */}
             <button
               id="claim-all"
-              onClick={handleClaimAllBatchRpc}
+              onClick={() => handleClaimBatch()}
               disabled={isClaimingSequentially || !isConnected || claimablePermitCount === 0}
               className="button-with-icon"
               title="Claim all valid & available permits (batch RPC)"
@@ -210,7 +218,7 @@ export function DashboardPage() {
                 {isLoading ? (
                   "Loading Rewards..."
                 ) : isQuoting ? (
-                   "Calculating..."
+                  "Calculating..."
                 ) : (
                   <>
                     <span className="claim-amount">{estimatedTotalValueDisplay}</span>
@@ -233,8 +241,6 @@ export function DashboardPage() {
           <div>Wallet not connected.</div>
         )}
       </section>
-
-
 
       {/* Error Displays */}
       {dataError && (
@@ -269,10 +275,16 @@ export function DashboardPage() {
         <section id="swap-status-wrapper" style={{ marginTop: "10px" }}>
           <h3>Swap Status:</h3>
           {Object.entries(swapSubmissionStatus).map(([key, status]) => (
-            <div key={key} className={`swap-status ${status.status === 'error' ? 'error-message' : status.status === 'submitted' ? 'success-message' : 'info-message'}`} style={{marginBottom: '5px', padding: '5px', border: '1px solid #ccc', borderRadius: '4px'}}>
-              {status.status === 'error' && ICONS.WARNING}
-              {status.status === 'submitted' && ICONS.CLAIM} {/* Use CLAIM icon as placeholder for SUCCESS */}
-              {status.status === 'submitting' && <div className="spinner" style={{width: '12px', height: '12px', marginRight: '5px', display: 'inline-block'}}></div>}
+            <div
+              key={key}
+              className={`swap-status ${status.status === "error" ? "error-message" : status.status === "submitted" ? "success-message" : "info-message"}`}
+              style={{ marginBottom: "5px", padding: "5px", border: "1px solid #ccc", borderRadius: "4px" }}
+            >
+              {status.status === "error" && ICONS.WARNING}
+              {status.status === "submitted" && ICONS.CLAIM} {/* Use CLAIM icon as placeholder for SUCCESS */}
+              {status.status === "submitting" && (
+                <div className="spinner" style={{ width: "12px", height: "12px", marginRight: "5px", display: "inline-block" }}></div>
+              )}
               <span>{status.message}</span>
               {/* Optionally add link to CowSwap explorer using orderUid if available */}
               {/* {status.orderUid && <a href={`https://explorer.cow.fi/orders/${status.orderUid}`} target="_blank" rel="noopener noreferrer"> View Order</a>} */}
@@ -286,6 +298,8 @@ export function DashboardPage() {
         <PermitsTable
           permits={permits}
           onClaimPermit={handleClaimPermit} // Pass down from usePermitClaiming
+          onClaimBatch={handleClaimBatch}
+          onClaimSequential={handleClaimSequential}
           isConnected={isConnected}
           chain={chain}
           // Removed isConfirming prop since we now track per-permit claimStatus
@@ -303,7 +317,6 @@ export function DashboardPage() {
           onPreferenceChange={handlePreferenceChange} // Restore onPreferenceChange prop
         />
       )}
-
     </>
   );
 }

--- a/frontend/src/components/permit-row.tsx
+++ b/frontend/src/components/permit-row.tsx
@@ -1,14 +1,14 @@
-import type { PermitData } from "../types.ts";
-import { formatAmount, hasRequiredFields } from "../utils/permit-utils.ts";
 import { useState } from "react";
-import type { Chain, Address } from "viem";
+import type { Address, Chain } from "viem";
 import { formatUnits } from "viem";
 import { useAccount } from "wagmi";
 import { switchNetwork } from "wagmi/actions";
-import { config } from "../main.tsx";
-import { ICONS } from "./iconography.tsx";
+import { NETWORK_NAMES, NEW_PERMIT2_ADDRESS } from "../constants/config.ts";
 import { getTokenInfo } from "../constants/supported-reward-tokens.ts";
-import { NETWORK_NAMES, PERMIT_AGGREGATOR_ADDRESS } from "../constants/config.ts";
+import { config } from "../main.tsx";
+import type { PermitData } from "../types.ts";
+import { formatAmount, hasRequiredFields } from "../utils/permit-utils.ts";
+import { ICONS } from "./iconography.tsx";
 
 interface PermitRowProps {
   permit: PermitData;
@@ -222,11 +222,11 @@ export function PermitRow({
   };
 
   // Check if permit uses the aggregator contract
-  const usesAggregator = permit.spender.toLowerCase() === PERMIT_AGGREGATOR_ADDRESS.toLowerCase();
+  const supportsBatchClaim = permit.permit2Address.toLowerCase() === NEW_PERMIT2_ADDRESS.toLowerCase();
 
   return (
     <div className={`permit-row ${rowClassName}`}>
-      {usesAggregator && onSelect && (
+      {supportsBatchClaim && onSelect && (
         <div className="permit-cell checkbox-cell">
           <input
             type="checkbox"

--- a/frontend/src/components/permits-table.tsx
+++ b/frontend/src/components/permits-table.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import type { Address, Chain } from "viem";
+import { NEW_PERMIT2_ADDRESS, OLD_PERMIT2_ADDRESS } from "../constants/config.ts";
 import type { PermitData } from "../types.ts";
-import { PermitRow } from "./permit-row.tsx";
-import type { Chain, Address } from "viem";
-import { PERMIT2_ADDRESS, PERMIT_AGGREGATOR_ADDRESS } from "../constants/config.ts";
 import { ClaimAllProgress } from "./claim-all-progress.tsx";
+import { PermitRow } from "./permit-row.tsx";
 
 interface PermitsTableProps {
   permits: PermitData[];
@@ -34,22 +34,14 @@ export function PermitsTable({
 
   // Split permits into aggregatable and regular
   // Only show valid and unprocessed permits
-  const validPermits = permits.filter(p =>
-    p.status === "Valid" &&
-    p.claimStatus !== "Success" &&
-    p.claimStatus !== "Pending"
-  );
+  const validPermits = permits.filter((p) => p.status === "Valid" && p.claimStatus !== "Success" && p.claimStatus !== "Pending");
 
   // Split into aggregatable (new) and regular (old) permits
-  const aggregatablePermits = validPermits.filter(p =>
-    p.spender.toLowerCase() === PERMIT_AGGREGATOR_ADDRESS.toLowerCase()
-  );
-  const regularPermits = validPermits.filter(p =>
-    p.spender.toLowerCase() === PERMIT2_ADDRESS.toLowerCase()
-  );
+  const aggregatablePermits = validPermits.filter((permit) => permit.permit2Address.toLowerCase() === NEW_PERMIT2_ADDRESS.toLowerCase());
+  const regularPermits = validPermits.filter((permit) => permit.permit2Address.toLowerCase() === OLD_PERMIT2_ADDRESS.toLowerCase());
 
   const togglePermitSelection = (permit: PermitData) => {
-    const key = `${permit.nonce}-${permit.networkId}`;
+    const key = permit.signature;
     const newSelected = new Set(selectedPermits);
     if (selectedPermits.has(key)) {
       newSelected.delete(key);
@@ -60,15 +52,13 @@ export function PermitsTable({
   };
 
   const isPermitSelected = (permit: PermitData) => {
-    return selectedPermits.has(`${permit.nonce}-${permit.networkId}`);
+    return selectedPermits.has(permit.signature);
   };
 
   const handleClaimSelected = async () => {
     if (!onAggregateClaim) return;
 
-    const selectedPermitsList = aggregatablePermits.filter(permit =>
-      selectedPermits.has(`${permit.nonce}-${permit.networkId}`)
-    );
+    const selectedPermitsList = aggregatablePermits.filter((permit) => selectedPermits.has(permit.signature));
 
     if (selectedPermitsList.length > 0) {
       const result = await onAggregateClaim(selectedPermitsList);
@@ -102,12 +92,7 @@ export function PermitsTable({
             )}
             {aggregatablePermits.length > 0 && (
               <>
-                <button
-                  type="button"
-                  onClick={handleClaimSelected}
-                  disabled={selectedPermits.size === 0}
-                  className="claim-selected-btn"
-                >
+                <button type="button" onClick={handleClaimSelected} disabled={selectedPermits.size === 0} className="claim-selected-btn">
                   Claim Selected ({selectedPermits.size})
                 </button>
                 <button
@@ -126,7 +111,7 @@ export function PermitsTable({
             <div className="permits-body">
               {validPermits.map((permit) => (
                 <PermitRow
-                  key={permit.nonce + permit.networkId}
+                  key={permit.signature}
                   permit={permit}
                   onClaimPermit={onClaimPermit}
                   isConnected={isConnected}

--- a/frontend/src/components/permits-table.tsx
+++ b/frontend/src/components/permits-table.tsx
@@ -8,8 +8,8 @@ import { PermitRow } from "./permit-row.tsx";
 interface PermitsTableProps {
   permits: PermitData[];
   onClaimPermit: (permit: PermitData) => Promise<{ success: boolean; txHash: string }>;
-  onClaimAll: () => void;
-  onAggregateClaim?: (permits: PermitData[]) => Promise<{ success: boolean; txHash: string }>;
+  onClaimSequential: (permits: PermitData[]) => void;
+  onClaimBatch: (permits?: PermitData[]) => Promise<{ success: boolean; txHash: string }>;
   isConnected: boolean;
   chain: Chain | undefined;
   claimTxHash?: `0x${string}`;
@@ -21,8 +21,8 @@ interface PermitsTableProps {
 export function PermitsTable({
   permits,
   onClaimPermit,
-  onClaimAll,
-  onAggregateClaim,
+  onClaimSequential,
+  onClaimBatch,
   isConnected,
   chain,
   claimTxHash,
@@ -56,12 +56,10 @@ export function PermitsTable({
   };
 
   const handleClaimSelected = async () => {
-    if (!onAggregateClaim) return;
-
     const selectedPermitsList = aggregatablePermits.filter((permit) => selectedPermits.has(permit.signature));
 
     if (selectedPermitsList.length > 0) {
-      const result = await onAggregateClaim(selectedPermitsList);
+      const result = await onClaimBatch(selectedPermitsList);
       if (result.success) {
         setSelectedPermits(new Set()); // Clear selection after successful claim
       }
@@ -86,7 +84,7 @@ export function PermitsTable({
         <div>
           <div style={{ display: "flex", alignItems: "center", marginBottom: 12, gap: 12 }}>
             {regularPermits.length > 0 && (
-              <button type="button" onClick={onClaimAll} className="claim-all-btn">
+              <button type="button" onClick={() => onClaimSequential(regularPermits)} className="claim-all-btn">
                 Queue All Regular Claims
               </button>
             )}
@@ -95,12 +93,7 @@ export function PermitsTable({
                 <button type="button" onClick={handleClaimSelected} disabled={selectedPermits.size === 0} className="claim-selected-btn">
                   Claim Selected ({selectedPermits.size})
                 </button>
-                <button
-                  type="button"
-                  onClick={() => onAggregateClaim?.(aggregatablePermits)}
-                  disabled={aggregatablePermits.length === 0}
-                  className="claim-all-btn"
-                >
+                <button type="button" onClick={() => onClaimBatch(aggregatablePermits)} disabled={aggregatablePermits.length === 0} className="claim-all-btn">
                   Batch Claim All
                 </button>
               </>

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -17,7 +17,8 @@ export const COWSWAP_PARTNER_FEE_BPS = 10;
 export const RPC_URL = import.meta.env.VITE_RPC_URL || "https://rpc.ubq.fi";
 
 // Universal contract addresses (same on all chains)
-export const PERMIT2_ADDRESS: Address = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+export const OLD_PERMIT2_ADDRESS: Address = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+export const NEW_PERMIT2_ADDRESS: Address = "0xd635918A75356D133d5840eE5c9ED070302C9C60";
 
 /**
  * PermitAggregator contract address - deterministic across all chains via CREATE2
@@ -30,5 +31,6 @@ export const PERMIT_AGGREGATOR_ADDRESS: Address = "0xDc64a140Aa3E981100a9becA4E6
 export const NETWORK_NAMES: { [chainId: number]: string } = {
   1: "Mainnet",
   100: "Gnosis",
+  31337: "Anvil",
   // Add other supported network names as needed
 };

--- a/frontend/src/fixtures/permit2-abi.ts
+++ b/frontend/src/fixtures/permit2-abi.ts
@@ -1,1 +1,434 @@
-export default [{"inputs":[{"internalType":"uint256","name":"deadline","type":"uint256"}],"name":"AllowanceExpired","type":"error"},{"inputs":[],"name":"ExcessiveInvalidation","type":"error"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"InsufficientAllowance","type":"error"},{"inputs":[{"internalType":"uint256","name":"maxAmount","type":"uint256"}],"name":"InvalidAmount","type":"error"},{"inputs":[],"name":"InvalidContractSignature","type":"error"},{"inputs":[],"name":"InvalidNonce","type":"error"},{"inputs":[],"name":"InvalidSignature","type":"error"},{"inputs":[],"name":"InvalidSignatureLength","type":"error"},{"inputs":[],"name":"InvalidSigner","type":"error"},{"inputs":[],"name":"LengthMismatch","type":"error"},{"inputs":[{"internalType":"uint256","name":"signatureDeadline","type":"uint256"}],"name":"SignatureExpired","type":"error"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"address","name":"token","type":"address"},{"indexed":false,"internalType":"address","name":"spender","type":"address"}],"name":"Lockdown","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint48","name":"newNonce","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"oldNonce","type":"uint48"}],"name":"NonceInvalidation","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"token","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint160","name":"amount","type":"uint160"},{"indexed":false,"internalType":"uint48","name":"expiration","type":"uint48"},{"indexed":false,"internalType":"uint48","name":"nonce","type":"uint48"}],"name":"Permit","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":false,"internalType":"uint256","name":"word","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"mask","type":"uint256"}],"name":"UnorderedNonceInvalidation","type":"event"},{"inputs":[],"name":"DOMAIN_SEPARATOR","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"},{"internalType":"address","name":"","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"}],"name":"approve","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint48","name":"newNonce","type":"uint48"}],"name":"invalidateNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"wordPos","type":"uint256"},{"internalType":"uint256","name":"mask","type":"uint256"}],"name":"invalidateUnorderedNonces","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"internalType":"struct IAllowanceTransfer.TokenSpenderPair[]","name":"approvals","type":"tuple[]"}],"name":"lockdown","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"nonceBitmap","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails[]","name":"details","type":"tuple[]"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitBatch","name":"permitBatch","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"uint48","name":"expiration","type":"uint48"},{"internalType":"uint48","name":"nonce","type":"uint48"}],"internalType":"struct IAllowanceTransfer.PermitDetails","name":"details","type":"tuple"},{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"sigDeadline","type":"uint256"}],"internalType":"struct IAllowanceTransfer.PermitSingle","name":"permitSingle","type":"tuple"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions[]","name":"permitted","type":"tuple[]"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitBatchTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails[]","name":"transferDetails","type":"tuple[]"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions","name":"permitted","type":"tuple"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails","name":"transferDetails","type":"tuple"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"components":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"internalType":"struct ISignatureTransfer.TokenPermissions[]","name":"permitted","type":"tuple[]"},{"internalType":"uint256","name":"nonce","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"internalType":"struct ISignatureTransfer.PermitBatchTransferFrom","name":"permit","type":"tuple"},{"components":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"requestedAmount","type":"uint256"}],"internalType":"struct ISignatureTransfer.SignatureTransferDetails[]","name":"transferDetails","type":"tuple[]"},{"internalType":"address","name":"owner","type":"address"},{"internalType":"bytes32","name":"witness","type":"bytes32"},{"internalType":"string","name":"witnessTypeString","type":"string"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"permitWitnessTransferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"components":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"internalType":"struct IAllowanceTransfer.AllowanceTransferDetails[]","name":"transferDetails","type":"tuple[]"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint160","name":"amount","type":"uint160"},{"internalType":"address","name":"token","type":"address"}],"name":"transferFrom","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+export default [
+  { inputs: [{ internalType: "uint256", name: "deadline", type: "uint256" }], name: "AllowanceExpired", type: "error" },
+  { inputs: [], name: "ExcessiveInvalidation", type: "error" },
+  { inputs: [{ internalType: "uint256", name: "amount", type: "uint256" }], name: "InsufficientAllowance", type: "error" },
+  { inputs: [{ internalType: "uint256", name: "maxAmount", type: "uint256" }], name: "InvalidAmount", type: "error" },
+  { inputs: [], name: "InvalidContractSignature", type: "error" },
+  { inputs: [], name: "InvalidNonce", type: "error" },
+  { inputs: [], name: "InvalidSignature", type: "error" },
+  { inputs: [], name: "InvalidSignatureLength", type: "error" },
+  { inputs: [], name: "InvalidSigner", type: "error" },
+  { inputs: [], name: "LengthMismatch", type: "error" },
+  { inputs: [{ internalType: "uint256", name: "signatureDeadline", type: "uint256" }], name: "SignatureExpired", type: "error" },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "owner", type: "address" },
+      { indexed: true, internalType: "address", name: "token", type: "address" },
+      { indexed: true, internalType: "address", name: "spender", type: "address" },
+      { indexed: false, internalType: "uint160", name: "amount", type: "uint160" },
+      { indexed: false, internalType: "uint48", name: "expiration", type: "uint48" },
+    ],
+    name: "Approval",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "owner", type: "address" },
+      { indexed: false, internalType: "address", name: "token", type: "address" },
+      { indexed: false, internalType: "address", name: "spender", type: "address" },
+    ],
+    name: "Lockdown",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "owner", type: "address" },
+      { indexed: true, internalType: "address", name: "token", type: "address" },
+      { indexed: true, internalType: "address", name: "spender", type: "address" },
+      { indexed: false, internalType: "uint48", name: "newNonce", type: "uint48" },
+      { indexed: false, internalType: "uint48", name: "oldNonce", type: "uint48" },
+    ],
+    name: "NonceInvalidation",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "owner", type: "address" },
+      { indexed: true, internalType: "address", name: "token", type: "address" },
+      { indexed: true, internalType: "address", name: "spender", type: "address" },
+      { indexed: false, internalType: "uint160", name: "amount", type: "uint160" },
+      { indexed: false, internalType: "uint48", name: "expiration", type: "uint48" },
+      { indexed: false, internalType: "uint48", name: "nonce", type: "uint48" },
+    ],
+    name: "Permit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, internalType: "address", name: "owner", type: "address" },
+      { indexed: false, internalType: "uint256", name: "word", type: "uint256" },
+      { indexed: false, internalType: "uint256", name: "mask", type: "uint256" },
+    ],
+    name: "UnorderedNonceInvalidation",
+    type: "event",
+  },
+  { inputs: [], name: "DOMAIN_SEPARATOR", outputs: [{ internalType: "bytes32", name: "", type: "bytes32" }], stateMutability: "view", type: "function" },
+  {
+    inputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "address", name: "", type: "address" },
+    ],
+    name: "allowance",
+    outputs: [
+      { internalType: "uint160", name: "amount", type: "uint160" },
+      { internalType: "uint48", name: "expiration", type: "uint48" },
+      { internalType: "uint48", name: "nonce", type: "uint48" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "address", name: "spender", type: "address" },
+      { internalType: "uint160", name: "amount", type: "uint160" },
+      { internalType: "uint48", name: "expiration", type: "uint48" },
+    ],
+    name: "approve",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "token", type: "address" },
+      { internalType: "address", name: "spender", type: "address" },
+      { internalType: "uint48", name: "newNonce", type: "uint48" },
+    ],
+    name: "invalidateNonces",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "wordPos", type: "uint256" },
+      { internalType: "uint256", name: "mask", type: "uint256" },
+    ],
+    name: "invalidateUnorderedNonces",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "token", type: "address" },
+          { internalType: "address", name: "spender", type: "address" },
+        ],
+        internalType: "struct IAllowanceTransfer.TokenSpenderPair[]",
+        name: "approvals",
+        type: "tuple[]",
+      },
+    ],
+    name: "lockdown",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "uint256", name: "", type: "uint256" },
+    ],
+    name: "nonceBitmap",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "owner", type: "address" },
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint160", name: "amount", type: "uint160" },
+              { internalType: "uint48", name: "expiration", type: "uint48" },
+              { internalType: "uint48", name: "nonce", type: "uint48" },
+            ],
+            internalType: "struct IAllowanceTransfer.PermitDetails[]",
+            name: "details",
+            type: "tuple[]",
+          },
+          { internalType: "address", name: "spender", type: "address" },
+          { internalType: "uint256", name: "sigDeadline", type: "uint256" },
+        ],
+        internalType: "struct IAllowanceTransfer.PermitBatch",
+        name: "permitBatch",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "owner", type: "address" },
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint160", name: "amount", type: "uint160" },
+              { internalType: "uint48", name: "expiration", type: "uint48" },
+              { internalType: "uint48", name: "nonce", type: "uint48" },
+            ],
+            internalType: "struct IAllowanceTransfer.PermitDetails",
+            name: "details",
+            type: "tuple",
+          },
+          { internalType: "address", name: "spender", type: "address" },
+          { internalType: "uint256", name: "sigDeadline", type: "uint256" },
+        ],
+        internalType: "struct IAllowanceTransfer.PermitSingle",
+        name: "permitSingle",
+        type: "tuple",
+      },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint256", name: "amount", type: "uint256" },
+            ],
+            internalType: "struct ISignatureTransfer.TokenPermissions",
+            name: "permitted",
+            type: "tuple",
+          },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "uint256", name: "deadline", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.PermitTransferFrom",
+        name: "permit",
+        type: "tuple",
+      },
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "requestedAmount", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.SignatureTransferDetails",
+        name: "transferDetails",
+        type: "tuple",
+      },
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permitTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint256", name: "amount", type: "uint256" },
+            ],
+            internalType: "struct ISignatureTransfer.TokenPermissions[]",
+            name: "permitted",
+            type: "tuple[]",
+          },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "uint256", name: "deadline", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.PermitBatchTransferFrom",
+        name: "permit",
+        type: "tuple",
+      },
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "requestedAmount", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.SignatureTransferDetails[]",
+        name: "transferDetails",
+        type: "tuple[]",
+      },
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permitTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint256", name: "amount", type: "uint256" },
+            ],
+            internalType: "struct ISignatureTransfer.TokenPermissions",
+            name: "permitted",
+            type: "tuple",
+          },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "uint256", name: "deadline", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.PermitTransferFrom",
+        name: "permit",
+        type: "tuple",
+      },
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "requestedAmount", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.SignatureTransferDetails",
+        name: "transferDetails",
+        type: "tuple",
+      },
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "bytes32", name: "witness", type: "bytes32" },
+      { internalType: "string", name: "witnessTypeString", type: "string" },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permitWitnessTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint256", name: "amount", type: "uint256" },
+            ],
+            internalType: "struct ISignatureTransfer.TokenPermissions[]",
+            name: "permitted",
+            type: "tuple[]",
+          },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "uint256", name: "deadline", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.PermitBatchTransferFrom",
+        name: "permit",
+        type: "tuple",
+      },
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "requestedAmount", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.SignatureTransferDetails[]",
+        name: "transferDetails",
+        type: "tuple[]",
+      },
+      { internalType: "address", name: "owner", type: "address" },
+      { internalType: "bytes32", name: "witness", type: "bytes32" },
+      { internalType: "string", name: "witnessTypeString", type: "string" },
+      { internalType: "bytes", name: "signature", type: "bytes" },
+    ],
+    name: "permitWitnessTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "from", type: "address" },
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint160", name: "amount", type: "uint160" },
+          { internalType: "address", name: "token", type: "address" },
+        ],
+        internalType: "struct IAllowanceTransfer.AllowanceTransferDetails[]",
+        name: "transferDetails",
+        type: "tuple[]",
+      },
+    ],
+    name: "transferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "address", name: "from", type: "address" },
+      { internalType: "address", name: "to", type: "address" },
+      { internalType: "uint160", name: "amount", type: "uint160" },
+      { internalType: "address", name: "token", type: "address" },
+    ],
+    name: "transferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: "address", name: "token", type: "address" },
+              { internalType: "uint256", name: "amount", type: "uint256" },
+            ],
+            internalType: "struct ISignatureTransfer.TokenPermissions",
+            name: "permitted",
+            type: "tuple",
+          },
+          { internalType: "uint256", name: "nonce", type: "uint256" },
+          { internalType: "uint256", name: "deadline", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.PermitTransferFrom[]",
+        name: "permits",
+        type: "tuple[]",
+      },
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "requestedAmount", type: "uint256" },
+        ],
+        internalType: "struct ISignatureTransfer.SignatureTransferDetails[]",
+        name: "transferDetails",
+        type: "tuple[]",
+      },
+      {
+        internalType: "address[]",
+        name: "owners",
+        type: "address[]",
+      },
+      {
+        internalType: "bytes[]",
+        name: "signatures",
+        type: "bytes[]",
+      },
+    ],
+    name: "batchPermitTransferFrom",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];

--- a/frontend/src/hooks/use-permit-claiming.ts
+++ b/frontend/src/hooks/use-permit-claiming.ts
@@ -1,40 +1,25 @@
 // use-permit-claiming.ts: Handles single and batch permit claiming
 
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
+import { Address, Chain, PublicClient, WalletClient } from "viem";
+import { NEW_PERMIT2_ADDRESS } from "../constants/config.ts";
 import permit2Abi from "../fixtures/permit2-abi.ts";
+import { PermitData } from "../types.ts";
 
 if (!permit2Abi) {
   throw new Error("Permit2 ABI could not be loaded");
 }
-import { PublicClient, WalletClient, Address, Chain } from "viem";
-
-interface PermitDataFixed {
-  nonce: string;
-  amount?: string;
-  token_id?: number | null;
-  networkId: number;
-  beneficiary: string;
-  deadline: string;
-  signature: string;
-  type: "erc20-permit" | "erc721-permit";
-  owner: string;
-  tokenAddress?: string;
-  githubCommentUrl: string;
-  token?: { address: string; network: number; decimals?: number };
-  status?: "Valid" | "Claimed" | "Expired" | "Invalid" | "Fetching" | "Testing";
-  claimStatus?: "Idle" | "Pending" | "Success" | "Error";
-}
 
 interface UsePermitClaimingProps {
-  permits: PermitDataFixed[];
-  setPermits: React.Dispatch<React.SetStateAction<PermitDataFixed[]>>;
+  permits: PermitData[];
+  setPermits: React.Dispatch<React.SetStateAction<PermitData[]>>;
   setError: React.Dispatch<React.SetStateAction<string | null>>;
-  updatePermitStatusCache: (permitKey: string, status: Partial<PermitDataFixed>) => void;
+  updatePermitStatusCache: (permitKey: string, status: Partial<PermitData>) => void;
   publicClient: PublicClient | null;
   walletClient: WalletClient | null;
   address: Address | undefined;
   chain: Chain | null;
-  claimablePermits?: PermitDataFixed[];
+  claimablePermits?: PermitData[];
 }
 
 export function usePermitClaiming({
@@ -54,21 +39,15 @@ export function usePermitClaiming({
   const [swapSubmissionStatus] = useState<Record<string, { status: string; message: string }>>({});
 
   const handleClaimPermit = useCallback(
-    async (permit: PermitDataFixed): Promise<{ success: boolean; txHash: string }> => {
-        const permitKey = `${permit.nonce}-${permit.networkId}`;
+    async (permit: PermitData): Promise<{ success: boolean; txHash: string }> => {
+      const permitKey = permit.signature;
 
-        if (!address || !chain || !walletClient || !publicClient) {
-            setError("Wallet not connected or chain unavailable");
-            return { success: false, txHash: "" };
-        }
+      if (!address || !chain || !walletClient || !publicClient) {
+        setError("Wallet not connected or chain unavailable");
+        return { success: false, txHash: "" };
+      }
 
-      setPermits(prev =>
-        prev.map(p =>
-          p.nonce === permit.nonce && p.networkId === permit.networkId
-            ? {...p, claimStatus: "Pending"}
-            : p
-        )
-      );
+      setPermits((prev) => prev.map((p) => (p.nonce === permit.nonce && p.networkId === permit.networkId ? { ...p, claimStatus: "Pending" } : p)));
 
       try {
         setClaimTxHash(undefined);
@@ -79,26 +58,26 @@ export function usePermitClaiming({
         }
 
         const { request } = await publicClient.simulateContract({
-          address: permit.tokenAddress as Address,
+          address: permit.permit2Address,
           abi: permit2Abi,
-          functionName: 'permitTransferFrom',
+          functionName: "permitTransferFrom",
           args: [
             {
               permitted: {
                 token: permit.tokenAddress,
-                amount: permit.amount
+                amount: BigInt(permit.amount ?? 0),
               },
-              nonce: permit.nonce,
-              deadline: permit.deadline
+              nonce: BigInt(permit.nonce),
+              deadline: BigInt(permit.deadline),
             },
             {
               to: address,
-              requestedAmount: permit.amount
+              requestedAmount: BigInt(permit.amount ?? 0),
             },
             permit.owner,
-            permit.signature
+            permit.signature,
           ],
-          account: address
+          account: address,
         });
 
         console.log("Transaction simulation successful", { request });
@@ -112,30 +91,23 @@ export function usePermitClaiming({
         console.log("Transaction completed", { receipt });
 
         // Update status to success
-        setPermits(prev =>
-          prev.map(p =>
-            p.nonce === permit.nonce && p.networkId === permit.networkId
-              ? {...p, claimStatus: "Success", status: "Claimed"}
-              : p
-          )
+        setPermits((prev) =>
+          prev.map((p) => (p.nonce === permit.nonce && p.networkId === permit.networkId ? { ...p, claimStatus: "Success", status: "Claimed" } : p))
         );
-        updatePermitStatusCache(`${permit.nonce}-${permit.networkId}`, { status: "Claimed" });
+        updatePermitStatusCache(permit.signature, { status: "Claimed" });
 
         // Record transaction in database
         try {
-          const txUrl = `https://etherscan.io/tx/${txHash}`;
-          await fetch('/api/permits/record-claim', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+          await fetch("/api/permits/record-claim", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              nonce: permit.nonce,
+              signature: permit.signature,
               transactionHash: txHash,
-              claimerAddress: address,
-              txUrl
-            })
+            }),
           });
         } catch (error) {
-          console.error('Failed to record transaction:', error);
+          console.error("Failed to record transaction:", error);
         }
 
         return { success: true, txHash };
@@ -144,7 +116,7 @@ export function usePermitClaiming({
           error,
           permitKey,
           nonce: permit.nonce,
-          networkId: permit.networkId
+          networkId: permit.networkId,
         });
 
         if (error instanceof Error && error.message.includes("InvalidNonce")) {
@@ -152,13 +124,7 @@ export function usePermitClaiming({
           updatePermitStatusCache(permitKey, { status: "Invalid" });
         }
 
-        setPermits(prev =>
-          prev.map(p =>
-            p.nonce === permit.nonce && p.networkId === permit.networkId
-              ? {...p, claimStatus: "Error"}
-              : p
-          )
-        );
+        setPermits((prev) => prev.map((p) => (p.nonce === permit.nonce && p.networkId === permit.networkId ? { ...p, claimStatus: "Error" } : p)));
         return { success: false, txHash: "" };
       } finally {
         // No need for setIsClaimConfirming since we use per-permit claimStatus
@@ -180,11 +146,7 @@ export function usePermitClaiming({
     setSequentialClaimError(null);
     setError(null);
 
-    const toClaim = claimablePermits || permits.filter(p =>
-      p.status === "Valid" &&
-      p.claimStatus !== "Success" &&
-      p.claimStatus !== "Pending"
-    );
+    const toClaim = claimablePermits || permits.filter((p) => p.status === "Valid" && p.claimStatus !== "Success" && p.claimStatus !== "Pending");
 
     if (!toClaim.length) {
       console.warn("Batch RPC: No claimable permits found");
@@ -194,82 +156,72 @@ export function usePermitClaiming({
     }
 
     console.log(`Starting batch RPC for ${toClaim.length} permits`, {
-      permits: toClaim.map(p => ({
+      permits: toClaim.map((p) => ({
         nonce: p.nonce,
         networkId: p.networkId,
-        token: p.tokenAddress
-      }))
+        token: p.tokenAddress,
+      })),
     });
 
     try {
       // Update all permits to pending status
-      setPermits(prev =>
-        prev.map(p =>
-          toClaim.some(c => c.nonce === p.nonce && c.networkId === p.networkId)
-            ? {...p, claimStatus: "Pending"}
-            : p
-        )
-      );
+      setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.nonce === p.nonce && c.networkId === p.networkId) ? { ...p, claimStatus: "Pending" } : p)));
 
-      // Process permits sequentially
-      let successCount = 0;
-      for (const permit of toClaim) {
-        const permitKey = `${permit.nonce}-${permit.networkId}`;
-        console.log(`Processing permit ${permitKey}`, {
-          nonce: permit.nonce,
-          networkId: permit.networkId,
-          type: permit.type,
-          token: permit.tokenAddress
-        });
+      const { request } = await publicClient.simulateContract({
+        address: NEW_PERMIT2_ADDRESS,
+        abi: permit2Abi,
+        functionName: "batchPermitTransferFrom",
+        args: [
+          permits.map((permit) => ({
+            permitted: {
+              token: permit.tokenAddress,
+              amount: BigInt(permit.amount ?? 0),
+            },
+            nonce: BigInt(permit.nonce),
+            deadline: BigInt(permit.deadline),
+          })),
+          permits.map((permit) => ({
+            to: address,
+            requestedAmount: BigInt(permit.amount ?? 0),
+          })),
+          permits.map((permit) => permit.owner),
+          permits.map((permit) => permit.signature),
+        ],
+        account: address,
+      });
 
-        try {
-          console.log(`Initiating RPC for permit ${permitKey}`);
-          const result = await handleClaimPermit(permit);
+      console.log("Transaction simulation successful", { request });
 
-          if (!result?.success || !result.txHash) {
-            console.error(`Batch RPC: Claim failed for permit ${permitKey}`);
-            setSequentialClaimError(`Failed to claim permit ${permit.nonce}`);
-            continue;
-          }
+      // 2. Send the actual transaction
+      const txHash = await walletClient.writeContract(request);
+      setClaimTxHash(txHash);
 
-          successCount++;
-          console.log(`Successfully processed RPC for permit ${permitKey}`);
+      // 3. Wait for transaction receipt
+      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+      console.log("Transaction completed", { receipt });
 
-          // Record transaction in database
-          try {
-            const txUrl = `https://etherscan.io/tx/${result.txHash}`;
-            await fetch('/api/permits/record-claim', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+      try {
+        await Promise.all(
+          permits.map((permit) => {
+            return fetch("http://localhost:8001/api/permits/record-claim", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                nonce: permit.nonce,
-                transactionHash: result.txHash,
-                claimerAddress: address,
-                txUrl
-              })
+                signature: permit.signature,
+                transactionHash: txHash,
+              }),
             });
-          } catch (error) {
-            console.error('Failed to record transaction:', error);
-          }
-        } catch (error) {
-          console.error(`Batch RPC: Failed to claim permit ${permitKey}`, {
-            error,
-            permit: permit.nonce,
-            network: permit.networkId
-          });
-          setSequentialClaimError(`Failed to claim permit ${permit.nonce}`);
-        }
+          })
+        );
+      } catch (error) {
+        console.error("Failed to record transaction:", error);
       }
 
-      console.log("Batch RPC completed", {
-        successCount,
-        total: toClaim.length,
-        successRate: `${Math.round((successCount / toClaim.length) * 100)}%`
-      });
+      console.log("Batch RPC completed");
     } catch (error) {
       console.error("Batch RPC: Unhandled processing error", {
         error,
-        context: "batch-processing"
+        context: "batch-processing",
       });
       setError("Batch claim failed");
     } finally {
@@ -285,6 +237,6 @@ export function usePermitClaiming({
     // Removed isClaimConfirming since we use per-permit claimStatus
     claimTxHash,
     swapSubmissionStatus,
-    walletConnectionError: !address || !chain ? "Wallet not connected" : null
+    walletConnectionError: !address || !chain ? "Wallet not connected" : null,
   };
 }

--- a/frontend/src/hooks/use-permit-claiming.ts
+++ b/frontend/src/hooks/use-permit-claiming.ts
@@ -47,7 +47,7 @@ export function usePermitClaiming({
         return { success: false, txHash: "" };
       }
 
-      setPermits((prev) => prev.map((p) => (p.nonce === permit.nonce && p.networkId === permit.networkId ? { ...p, claimStatus: "Pending" } : p)));
+      setPermits((prev) => prev.map((p) => (p.signature === permit.signature ? { ...p, claimStatus: "Pending" } : p)));
 
       try {
         setClaimTxHash(undefined);
@@ -91,9 +91,7 @@ export function usePermitClaiming({
         console.log("Transaction completed", { receipt });
 
         // Update status to success
-        setPermits((prev) =>
-          prev.map((p) => (p.nonce === permit.nonce && p.networkId === permit.networkId ? { ...p, claimStatus: "Success", status: "Claimed" } : p))
-        );
+        setPermits((prev) => prev.map((p) => (p.signature === permit.signature ? { ...p, claimStatus: "Success", status: "Claimed" } : p)));
         updatePermitStatusCache(permit.signature, { status: "Claimed" });
 
         // Record transaction in database
@@ -133,105 +131,216 @@ export function usePermitClaiming({
     [address, chain, walletClient, publicClient, setPermits, setError, updatePermitStatusCache]
   );
 
-  const handleClaimAllBatchRpc = useCallback(async () => {
-    if (!walletClient || !address || !chain || !publicClient) {
-      console.error("Batch RPC: Wallet not connected - client:", walletClient, "address:", address, "chain:", chain);
-      setError("Wallet not connected or chain unavailable");
-      return;
-    } else {
-      console.log("Batch RPC: Wallet connection verified - address:", address, "chain id:", chain.id);
-    }
-
-    setIsClaimingSequentially(true);
-    setSequentialClaimError(null);
-    setError(null);
-
-    const toClaim = claimablePermits || permits.filter((p) => p.status === "Valid" && p.claimStatus !== "Success" && p.claimStatus !== "Pending");
-
-    if (!toClaim.length) {
-      console.warn("Batch RPC: No claimable permits found");
-      setSequentialClaimError("No claimable permits found");
-      setIsClaimingSequentially(false);
-      return;
-    }
-
-    console.log(`Starting batch RPC for ${toClaim.length} permits`, {
-      permits: toClaim.map((p) => ({
-        nonce: p.nonce,
-        networkId: p.networkId,
-        token: p.tokenAddress,
-      })),
-    });
-
-    try {
-      // Update all permits to pending status
-      setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.nonce === p.nonce && c.networkId === p.networkId) ? { ...p, claimStatus: "Pending" } : p)));
-
-      const { request } = await publicClient.simulateContract({
-        address: NEW_PERMIT2_ADDRESS,
-        abi: permit2Abi,
-        functionName: "batchPermitTransferFrom",
-        args: [
-          permits.map((permit) => ({
-            permitted: {
-              token: permit.tokenAddress,
-              amount: BigInt(permit.amount ?? 0),
-            },
-            nonce: BigInt(permit.nonce),
-            deadline: BigInt(permit.deadline),
-          })),
-          permits.map((permit) => ({
-            to: address,
-            requestedAmount: BigInt(permit.amount ?? 0),
-          })),
-          permits.map((permit) => permit.owner),
-          permits.map((permit) => permit.signature),
-        ],
-        account: address,
-      });
-
-      console.log("Transaction simulation successful", { request });
-
-      // 2. Send the actual transaction
-      const txHash = await walletClient.writeContract(request);
-      setClaimTxHash(txHash);
-
-      // 3. Wait for transaction receipt
-      const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
-      console.log("Transaction completed", { receipt });
-
-      try {
-        await Promise.all(
-          permits.map((permit) => {
-            return fetch("http://localhost:8001/api/permits/record-claim", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                signature: permit.signature,
-                transactionHash: txHash,
-              }),
-            });
-          })
-        );
-      } catch (error) {
-        console.error("Failed to record transaction:", error);
+  const handleClaimSequential = useCallback(
+    async (permitsToClaim: PermitData[]) => {
+      if (!walletClient || !address || !chain || !publicClient) {
+        console.error("Sequential claim: Wallet not connected - client:", walletClient, "address:", address, "chain:", chain);
+        setError("Wallet not connected or chain unavailable");
+        return;
+      } else {
+        console.log("Sequential claim: Wallet connection verified - address:", address, "chain id:", chain.id);
       }
 
-      console.log("Batch RPC completed");
-    } catch (error) {
-      console.error("Batch RPC: Unhandled processing error", {
-        error,
-        context: "batch-processing",
+      setIsClaimingSequentially(true);
+      setSequentialClaimError(null);
+      setError(null);
+
+      const toClaim = permitsToClaim;
+
+      if (!toClaim.length) {
+        console.warn("Sequential claim: No claimable permits found");
+        setSequentialClaimError("No claimable permits found");
+        setIsClaimingSequentially(false);
+        return;
+      }
+
+      console.log(`Starting sequential claim for ${toClaim.length} permits`, {
+        permits: toClaim.map((p) => ({
+          nonce: p.nonce,
+          networkId: p.networkId,
+          token: p.tokenAddress,
+        })),
       });
-      setError("Batch claim failed");
-    } finally {
+
+      // Update all permits to pending status
+      setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.signature === p.signature) ? { ...p, claimStatus: "Pending" } : p)));
+
+      await Promise.allSettled(
+        toClaim.map(async (permit) => {
+          try {
+            const { request } = await publicClient.simulateContract({
+              address: permit.permit2Address,
+              abi: permit2Abi,
+              functionName: "permitTransferFrom",
+              args: [
+                {
+                  permitted: {
+                    token: permit.tokenAddress,
+                    amount: BigInt(permit.amount ?? 0),
+                  },
+                  nonce: BigInt(permit.nonce),
+                  deadline: BigInt(permit.deadline),
+                },
+                {
+                  to: address,
+                  requestedAmount: BigInt(permit.amount ?? 0),
+                },
+                permit.owner,
+                permit.signature,
+              ],
+              account: address,
+            });
+
+            console.log("Transaction simulation successful", { request });
+
+            // 2. Send the actual transaction
+            const txHash = await walletClient.writeContract(request);
+            setClaimTxHash(txHash);
+
+            // 3. Wait for transaction receipt
+            const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+            console.log("Transaction completed", { receipt });
+
+            // Update status to success
+            setPermits((prev) => prev.map((p) => (p.signature === permit.signature ? { ...p, claimStatus: "Success", status: "Claimed" } : p)));
+            updatePermitStatusCache(permit.signature, { status: "Claimed" });
+
+            // Record transaction in database
+            try {
+              await fetch("/api/permits/record-claim", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  signature: permit.signature,
+                  transactionHash: txHash,
+                }),
+              });
+            } catch (error) {
+              console.error("Failed to record transaction:", error);
+            }
+          } catch (error) {
+            console.error("Sequential claim processing error", { error });
+            setPermits((prev) => prev.map((p) => (p.signature === permit.signature ? { ...p, claimStatus: "Error" } : p)));
+          }
+        })
+      );
       setIsClaimingSequentially(false);
-    }
-  }, [claimablePermits, permits, handleClaimPermit, walletClient, address, chain, publicClient, setError, setPermits]);
+      console.log("Sequential claim completed successfully");
+    },
+    [claimablePermits, permits, handleClaimPermit, walletClient, address, chain, publicClient, setError, setPermits]
+  );
+
+  const handleClaimBatch = useCallback(
+    async (permitsToClaim?: PermitData[]) => {
+      if (!walletClient || !address || !chain || !publicClient) {
+        console.error("Batch RPC: Wallet not connected - client:", walletClient, "address:", address, "chain:", chain);
+        setError("Wallet not connected or chain unavailable");
+        return { success: false, txHash: "" };
+      } else {
+        console.log("Batch RPC: Wallet connection verified - address:", address, "chain id:", chain.id);
+      }
+
+      setIsClaimingSequentially(true);
+      setSequentialClaimError(null);
+      setError(null);
+
+      const toClaim =
+        permitsToClaim || claimablePermits || permits.filter((p) => p.status === "Valid" && p.claimStatus !== "Success" && p.claimStatus !== "Pending");
+
+      if (!toClaim.length) {
+        console.warn("Batch RPC: No claimable permits found");
+        setSequentialClaimError("No claimable permits found");
+        setIsClaimingSequentially(false);
+        return { success: false, txHash: "" };
+      }
+
+      console.log(`Starting batch RPC for ${toClaim.length} permits`, {
+        permits: toClaim.map((p) => ({
+          nonce: p.nonce,
+          networkId: p.networkId,
+          token: p.tokenAddress,
+        })),
+      });
+
+      let success = false;
+      let txHash: `0x${string}` | undefined;
+      try {
+        // Update all permits to pending status
+        setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.signature === p.signature) ? { ...p, claimStatus: "Pending" } : p)));
+
+        const { request } = await publicClient.simulateContract({
+          address: NEW_PERMIT2_ADDRESS,
+          abi: permit2Abi,
+          functionName: "batchPermitTransferFrom",
+          args: [
+            toClaim.map((permit) => ({
+              permitted: {
+                token: permit.tokenAddress,
+                amount: BigInt(permit.amount ?? 0),
+              },
+              nonce: BigInt(permit.nonce),
+              deadline: BigInt(permit.deadline),
+            })),
+            toClaim.map((permit) => ({
+              to: address,
+              requestedAmount: BigInt(permit.amount ?? 0),
+            })),
+            toClaim.map((permit) => permit.owner),
+            toClaim.map((permit) => permit.signature),
+          ],
+          account: address,
+        });
+
+        console.log("Transaction simulation successful", { request });
+
+        // 2. Send the actual transaction
+        txHash = await walletClient.writeContract(request);
+        setClaimTxHash(txHash);
+
+        // 3. Wait for transaction receipt
+        const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash });
+        console.log("Transaction completed", { receipt });
+
+        setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.signature === p.signature) ? { ...p, claimStatus: "Success", status: "Claimed" } : p)));
+        try {
+          await Promise.all(
+            permits.map((permit) => {
+              updatePermitStatusCache(permit.signature, { status: "Claimed" });
+              return fetch("http://localhost:8001/api/permits/record-claim", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  signature: permit.signature,
+                  transactionHash: txHash,
+                }),
+              });
+            })
+          );
+        } catch (error) {
+          console.error("Failed to record transaction:", error);
+        }
+
+        console.log("Batch RPC completed");
+        success = true;
+      } catch (error) {
+        console.error("Batch RPC: Unhandled processing error", {
+          error,
+          context: "batch-processing",
+        });
+        setPermits((prev) => prev.map((p) => (toClaim.some((c) => c.signature === p.signature) ? { ...p, claimStatus: "Error" } : p)));
+        setError("Batch claim failed");
+      } finally {
+        setIsClaimingSequentially(false);
+      }
+      return { success, txHash: String(txHash) };
+    },
+    [claimablePermits, permits, handleClaimPermit, walletClient, address, chain, publicClient, setError, setPermits]
+  );
 
   return {
     handleClaimPermit,
-    handleClaimAllBatchRpc,
+    handleClaimBatch,
+    handleClaimSequential,
     isClaimingSequentially,
     sequentialClaimError,
     // Removed isClaimConfirming since we use per-permit claimStatus

--- a/frontend/src/hooks/use-permit-data.ts
+++ b/frontend/src/hooks/use-permit-data.ts
@@ -56,7 +56,7 @@ export function usePermitData({
         }
         // Detailed log for each permit during filtering
         console.log("[use-permit-data] Filter check for permit", {
-          key: `${permit.nonce}-${permit.networkId}`,
+          key: permit.signature,
           status: permit.status,
           isNonceUsed: permit.isNonceUsed,
           checkError: permit.checkError,
@@ -207,8 +207,7 @@ export function usePermitData({
           console.log("[use-permit-data] Raw permit data fetched from Supabase:", validated);
           const cache: PermitDataCache = {};
           validated.forEach((permit) => {
-            const key = `${permit.nonce}-${permit.networkId}`;
-            cache[key] = permit;
+            cache[permit.signature] = permit;
           });
           saveCache(cache);
           allPermitsRef.current = new Map(Object.entries(cache));

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,6 +18,7 @@ import {
   avalanche, // 43114
   blast, // 81457
   zora, // 7777777
+  anvil, // 31337 (local dev chain)
 } from "wagmi/chains";
 // Removed Permit2RpcManager import as it's now used only in the worker
 import App from "./App.tsx";
@@ -41,6 +42,7 @@ const supportedChains = [
   avalanche,
   blast,
   zora,
+  anvil,
 ];
 
 // Get base RPC URL from env or use default

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,9 +11,6 @@ interface PartnerInfoInternal {
   };
 }
 
-// Constants for permit spender addresses
-export const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3" as const;
-
 // Keep PermitData as it seems to be used
 export interface PermitData {
   nonce: string;
@@ -23,33 +20,33 @@ export interface PermitData {
   beneficiary: string;
   deadline: string;
   signature: string;
-  type: 'erc20-permit' | 'erc721-permit';
+  type: "erc20-permit" | "erc721-permit";
   owner: string; // Funder
   tokenAddress?: string;
   githubCommentUrl: string;
   token?: TokenInfoInternal; // Use internal type
   partner?: PartnerInfoInternal; // Use internal type
-  spender: `0x${string}`; // The contract address that is authorized to spend the tokens (Permit2 or PermitAggregator)
+  permit2Address: `0x${string}`;
 
   // Frontend-specific statuses for validation/testing
-  status?: 'Valid' | 'Claimed' | 'Expired' | 'Invalid' | 'Fetching' | 'Testing';
+  status?: "Valid" | "Claimed" | "Expired" | "Invalid" | "Fetching" | "Testing";
   testError?: string; // For storing error messages during claim testing
 
-   // Frontend-specific statuses for actual claiming
-   claimStatus?: 'Idle' | 'Pending' | 'Success' | 'Error';
-   claimError?: string;
-   transactionHash?: string; // Store claim tx hash
+  // Frontend-specific statuses for actual claiming
+  claimStatus?: "Idle" | "Pending" | "Success" | "Error";
+  claimError?: string;
+  transactionHash?: string; // Store claim tx hash
 
-   // Frontend-specific checks for prerequisites (balance/allowance)
-   ownerBalanceSufficient?: boolean;
-   permit2AllowanceSufficient?: boolean;
-   checkError?: string; // Error during balance/allowance check
-   isNonceUsed?: boolean; // Added for nonce check result
+  // Frontend-specific checks for prerequisites (balance/allowance)
+  ownerBalanceSufficient?: boolean;
+  permit2AllowanceSufficient?: boolean;
+  checkError?: string; // Error during balance/allowance check
+  isNonceUsed?: boolean; // Added for nonce check result
 
-   // Estimated value (potentially added by backend)
-   usdValue?: number;
+  // Estimated value (potentially added by backend)
+  usdValue?: number;
 
-   // --- Fields for CowSwap Quote Estimation ---
-   estimatedAmountOut?: string; // Store as string (wei) to handle large numbers
-   quoteError?: string | null; // Error message if quote fetching fails for this permit's group
+  // --- Fields for CowSwap Quote Estimation ---
+  estimatedAmountOut?: string; // Store as string (wei) to handle large numbers
+  quoteError?: string | null; // Error message if quote fetching fails for this permit's group
 }

--- a/frontend/src/utils/permit-utils.ts
+++ b/frontend/src/utils/permit-utils.ts
@@ -1,4 +1,4 @@
-import { erc20Abi, type Abi, type Address, formatUnits } from "viem"; // Import formatUnits
+import { erc20Abi, formatUnits, type Abi, type Address } from "viem"; // Import formatUnits
 import type { PermitData } from "../types";
 
 // Removed unused MulticallContractInternal interface
@@ -10,8 +10,6 @@ type ContractCallConfig = {
   functionName: string;
   args?: unknown[];
 };
-
-const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3"; // Universal Permit2 address
 
 /**
  * Prepares the contract call objects for checking ERC20 permit prerequisites (balance and allowance).
@@ -36,7 +34,7 @@ export function preparePermitPrerequisiteContracts(permit: PermitData): Contract
     abi: erc20Abi,
     address: tokenAddress,
     functionName: "allowance",
-    args: [ownerAddress, PERMIT2_ADDRESS],
+    args: [ownerAddress, permit.permit2Address],
   };
 
   return [balanceCall, allowanceCall];

--- a/frontend/src/workers/permit-checker.worker.ts
+++ b/frontend/src/workers/permit-checker.worker.ts
@@ -1,10 +1,11 @@
-import { type Address, type Abi, parseAbiItem } from "viem";
-import type { PermitData } from "../types.ts";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { createRpcClient, type JsonRpcResponse } from '@ubiquity-dao/permit2-rpc-client';
-import { encodeFunctionData } from "viem";
-import { preparePermitPrerequisiteContracts } from "../utils/permit-utils.ts";
+import { createRpcClient, type JsonRpcResponse } from "@ubiquity-dao/permit2-rpc-client";
+import { PermitTransferFrom, SignatureTransfer } from "@uniswap/permit2-sdk";
+import { type Abi, type Address, encodeFunctionData, parseAbiItem, recoverAddress } from "viem";
+import { NEW_PERMIT2_ADDRESS, OLD_PERMIT2_ADDRESS } from "../constants/config.ts";
 import type { Database, Tables } from "../database.types.ts"; // Import generated types
+import type { PermitData } from "../types.ts";
+import { preparePermitPrerequisiteContracts } from "../utils/permit-utils.ts";
 
 // --- Worker Setup ---
 
@@ -34,484 +35,440 @@ let PROXY_BASE_URL = ""; // Will be set in INIT
 
 // Define type for JSON-RPC Request object
 interface JsonRpcRequest {
-    jsonrpc: '2.0';
-    method: string;
-    params: unknown[];
-    id: number | string;
+  jsonrpc: "2.0";
+  method: string;
+  params: unknown[];
+  id: number | string;
 }
 
 // Define expected message structure more specifically if possible
 interface WorkerPayload {
-    supabaseUrl?: string;
-    supabaseAnonKey?: string;
-    address?: Address;
-    lastCheckTimestamp?: string | null;
-    permits?: PermitData[]; // For VALIDATE_PERMITS
-    proxyBaseUrl?: string; // Pass proxy URL during init
-    [key: string]: unknown;
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+  address?: Address;
+  lastCheckTimestamp?: string | null;
+  permits?: PermitData[]; // For VALIDATE_PERMITS
+  proxyBaseUrl?: string; // Pass proxy URL during init
+  [key: string]: unknown;
 }
 
 // --- Database Fetching and Mapping ---
 
 // Type alias for permits row using generated types
-type PermitRow = Tables<'permits'> & {
-    token: Tables<'tokens'> | null;
-    partner: (Tables<'partners'> & { wallet: Tables<'wallets'> | null }) | null;
-    location: Tables<'locations'> | null;
+type PermitRow = Tables<"permits"> & {
+  token: Tables<"tokens"> | null;
+  partner: (Tables<"partners"> & { wallet: Tables<"wallets"> | null }) | null;
+  location: Tables<"locations"> | null;
 };
-
 
 // Function to map DB result to PermitData (ERC20 only focus)
 function mapDbPermitToPermitData(permit: PermitRow, index: number, lowerCaseWalletAddress: string): PermitData | null {
-    const tokenData = permit.token;
-    const ownerWalletData = permit.partner?.wallet;
-    const ownerAddressStr = ownerWalletData?.address ? String(ownerWalletData.address) : "";
-    const tokenAddressStr = tokenData?.address ? String(tokenData.address) : undefined;
-    const networkIdNum = Number(tokenData?.network ?? 0);
-    const githubUrlStr = permit.location?.node_url ? String(permit.location.node_url) : "";
+  const tokenData = permit.token;
+  const ownerWalletData = permit.partner?.wallet;
+  const ownerAddressStr = ownerWalletData?.address ? String(ownerWalletData.address) : "";
+  const tokenAddressStr = tokenData?.address ? String(tokenData.address) : undefined;
+  const networkIdNum = Number(tokenData?.network ?? 0);
+  const githubUrlStr = permit.location?.node_url ? String(permit.location.node_url) : "";
 
-    // Assume ERC20 if amount is positive, otherwise filter out.
-    let type: 'erc20-permit' | null = null;
-    let amountBigInt: bigint | null = null;
-    if (permit.amount !== undefined && permit.amount !== null) {
-        try {
-            amountBigInt = BigInt(permit.amount);
-        } catch {
-            console.warn(`Worker: Permit [${index}] with nonce ${permit.nonce} has invalid amount format: ${permit.amount}`);
-            amountBigInt = null;
-        }
+  // Assume ERC20 if amount is positive, otherwise filter out.
+  let type: "erc20-permit" | null = null;
+  let amountBigInt: bigint | null = null;
+  if (permit.amount !== undefined && permit.amount !== null) {
+    try {
+      amountBigInt = BigInt(permit.amount);
+    } catch {
+      console.warn(`Worker: Permit [${index}] with nonce ${permit.nonce} has invalid amount format: ${permit.amount}`);
+      amountBigInt = null;
     }
+  }
 
-    if (amountBigInt !== null && amountBigInt > 0n) {
-        type = "erc20-permit";
-    } else {
-        // Allow permits with 0 amount through mapping, filter later if needed
-        // if (index < 10) { console.warn(`Worker: Permit [${index}] with nonce ${permit.nonce} has no positive amount (${permit.amount}). Filtering out.`); }
-        // return null;
-        type = "erc20-permit"; // Still classify as ERC20 if amount is 0 or null, maybe filter later based on validation?
-    }
+  if (amountBigInt !== null && amountBigInt > 0n) {
+    type = "erc20-permit";
+  } else {
+    // Allow permits with 0 amount through mapping, filter later if needed
+    // if (index < 10) { console.warn(`Worker: Permit [${index}] with nonce ${permit.nonce} has no positive amount (${permit.amount}). Filtering out.`); }
+    // return null;
+    type = "erc20-permit"; // Still classify as ERC20 if amount is 0 or null, maybe filter later based on validation?
+  }
 
-    // Log type determination for the first few permits
+  // Log type determination for the first few permits
+  if (index < 10) {
+    // console.log(`Worker: Permit [${index}] mapped. Raw: {amount: ${permit.amount}}. Determined type: ${type}`);
+  }
+
+  const permitData: PermitData = {
+    nonce: String(permit.nonce),
+    networkId: networkIdNum,
+    beneficiary: lowerCaseWalletAddress, // Keep wallet address as beneficiary for UI/logic consistency
+    deadline: String(permit.deadline),
+    signature: String(permit.signature),
+    type: type,
+    owner: ownerAddressStr,
+    tokenAddress: tokenAddressStr,
+    token: tokenAddressStr ? { address: tokenAddressStr, network: networkIdNum } : undefined,
+    amount: permit.amount !== undefined && permit.amount !== null ? String(permit.amount) : undefined,
+    token_id: permit.token_id !== undefined && permit.token_id !== null ? Number(permit.token_id) : undefined,
+    githubCommentUrl: githubUrlStr,
+    partner: ownerAddressStr ? { wallet: { address: ownerAddressStr } } : undefined,
+    claimStatus: "Idle",
+    status: "Fetching",
+    ...(permit.created && { created_at: permit.created }), // Map 'created' from DB
+  };
+
+  // Basic validation (ensure essential fields are present)
+  if (!permitData.nonce || !permitData.deadline || !permitData.signature || !permitData.beneficiary || !permitData.owner || !permitData.token?.address) {
+    // Amount check removed as 0 is ok for type
     if (index < 10) {
-        // console.log(`Worker: Permit [${index}] mapped. Raw: {amount: ${permit.amount}}. Determined type: ${type}`);
+      console.warn(`Worker: Permit [${index}] missing essential data. Filtering out. Data:`, JSON.stringify(permitData));
     }
-
-    const permitData: PermitData = {
-        nonce: String(permit.nonce),
-        networkId: networkIdNum,
-        beneficiary: lowerCaseWalletAddress, // Keep wallet address as beneficiary for UI/logic consistency
-        deadline: String(permit.deadline),
-        signature: String(permit.signature),
-        type: type,
-        owner: ownerAddressStr,
-        tokenAddress: tokenAddressStr,
-        token: tokenAddressStr ? { address: tokenAddressStr, network: networkIdNum } : undefined,
-        amount: permit.amount !== undefined && permit.amount !== null ? String(permit.amount) : undefined,
-        token_id: permit.token_id !== undefined && permit.token_id !== null ? Number(permit.token_id) : undefined,
-        githubCommentUrl: githubUrlStr,
-        partner: ownerAddressStr ? { wallet: { address: ownerAddressStr } } : undefined,
-        claimStatus: "Idle",
-        ...(permit.created && { created_at: permit.created }) // Map 'created' from DB
-    };
-
-    // Basic validation (ensure essential fields are present)
-    if (!permitData.nonce || !permitData.deadline || !permitData.signature || !permitData.beneficiary || !permitData.owner || !permitData.token?.address) { // Amount check removed as 0 is ok for type
-        if (index < 10) { console.warn(`Worker: Permit [${index}] missing essential data. Filtering out. Data:`, JSON.stringify(permitData)); }
-        return null;
+    return null;
+  }
+  // Validate deadline format before parsing
+  if (typeof permitData.deadline !== "string" || isNaN(parseInt(permitData.deadline, 10))) {
+    if (index < 10) {
+      console.warn(`Worker: Permit [${index}] has invalid deadline format: ${permitData.deadline}. Filtering out.`);
     }
-    // Validate deadline format before parsing
-     if (typeof permitData.deadline !== 'string' || isNaN(parseInt(permitData.deadline, 10))) {
-         if (index < 10) { console.warn(`Worker: Permit [${index}] has invalid deadline format: ${permitData.deadline}. Filtering out.`); }
-         return null;
-     }
-    const deadlineInt = parseInt(permitData.deadline, 10);
-    if (isNaN(deadlineInt) || deadlineInt < Math.floor(Date.now() / 1000)) {
-        if (index < 10) { console.warn(`Worker: Permit [${index}] is expired. Filtering out.`); }
-        return null;
+    return null;
+  }
+  const deadlineInt = parseInt(permitData.deadline, 10);
+  if (isNaN(deadlineInt) || deadlineInt < Math.floor(Date.now() / 1000)) {
+    if (index < 10) {
+      console.warn(`Worker: Permit [${index}] is expired. Filtering out.`);
     }
-    return permitData;
+    permitData.status = "Expired";
+  }
+  return permitData;
 }
 
 // Function to fetch permits from Supabase using the proper relationships
 async function fetchPermitsFromDb(walletAddress: string, lastCheckTimestamp: string | null): Promise<PermitRow[]> {
-    if (!supabase) throw new Error("Supabase client not initialized.");
+  if (!supabase) throw new Error("Supabase client not initialized.");
 
-    // Normalize wallet address for consistent comparison
-    const normalizedWalletAddress = walletAddress.toLowerCase();
+  // Normalize wallet address for consistent comparison
+  const normalizedWalletAddress = walletAddress.toLowerCase();
 
-    console.log(`Worker: Attempting to fetch permits for wallet address: ${normalizedWalletAddress}`);
-    console.log(`Worker: Will try multiple query approaches to ensure we find all relevant permits`);
+  console.log(`Worker: Attempting to fetch permits for wallet address: ${normalizedWalletAddress}`);
+  let permitsData: unknown[] = [];
 
-    // APPROACH 1: Original approach - Find users associated with wallet, then find permits for those users
-    console.log(`Worker: APPROACH 1 - Find users via wallets table, then query permits`);
-
-    // Log the exact SQL query that would be executed (for debugging)
-    const walletQuery = supabase
-        .from('wallets')
-        .select('id, users!users_wallet_id_fkey(id)')
-        .or(`address.eq.${normalizedWalletAddress},address.ilike.${normalizedWalletAddress}`);
-
-    console.log(`Worker: SQL Query 1 (approximate): SELECT id, users FROM wallets WHERE address = '${normalizedWalletAddress}' OR address ILIKE '${normalizedWalletAddress}'`);
-
-    const { data: usersWithWallet, error: walletError } = await walletQuery;
-
-    if (walletError) {
-        console.error(`Worker: Supabase wallet fetch error: ${walletError.message}`, walletError);
-    }
-
-    let userIds: any[] = [];
-    if (usersWithWallet && usersWithWallet.length > 0) {
-        console.log(`Worker: Found ${usersWithWallet.length} wallet entries:`, JSON.stringify(usersWithWallet));
-
-        userIds = usersWithWallet
-            .flatMap(wallet => wallet.users)
-            .filter(Boolean)
-            .map(user => user.id);
-
-        console.log(`Worker: Extracted user IDs: ${JSON.stringify(userIds)}`);
-    } else {
-        console.log(`Worker: No users found with wallet address: ${normalizedWalletAddress} using approach 1`);
-    }
-
-    let permitsData: any[] = [];
-    let permitError: any = null;
-
-    // If we found user IDs, query permits for those users
-    if (userIds.length > 0) {
-        console.log(`Worker: Querying permits for user IDs: ${JSON.stringify(userIds)}`);
-
-        let query = supabase.from(PERMITS_TABLE)
-            .select(`*, created, token: ${TOKENS_TABLE} (address, network), partner: ${PARTNERS_TABLE} (wallet: ${WALLETS_TABLE} (address)), location: ${LOCATIONS_TABLE} (node_url)`)
-            .is("transaction", null)
-            .in("beneficiary_id", userIds);
-
-        if (lastCheckTimestamp && !isNaN(Date.parse(lastCheckTimestamp))) {
-            query = query.gt('created', lastCheckTimestamp);
-        }
-
-        console.log(`Worker: SQL Query (permits by user IDs): SELECT * FROM ${PERMITS_TABLE} WHERE transaction IS NULL AND beneficiary_id IN (${userIds.join(',')})${lastCheckTimestamp ? ` AND created > '${lastCheckTimestamp}'` : ''}`);
-
-        const result = await query;
-        permitError = result.error;
-        permitsData = result.data || [];
-
-        if (permitError) {
-            console.error(`Worker: Supabase permit fetch error: ${permitError.message}`, permitError);
-        } else {
-            console.log(`Worker: Found ${permitsData.length} permits using approach 1`);
-        }
-    }
-
-    // APPROACH 2: Direct join approach - Try a more direct join if the first approach didn't work
-    if (permitsData.length === 0 && !permitError) {
-        console.log(`Worker: APPROACH 2 - Using direct join to find permits`);
-
-        // This query directly joins permits with users and wallets
-        const directJoinQuery = `
-            permits(*),
+  // This query directly joins permits with users and wallets
+  const directJoinQuery = `
+            *,
             token:${TOKENS_TABLE}(address, network),
             partner:${PARTNERS_TABLE}(wallet:${WALLETS_TABLE}(address)),
             location:${LOCATIONS_TABLE}(node_url),
             users!inner(
                 wallets!inner(address)
             )
-        `;
+  `;
 
-        console.log(`Worker: SQL Query 2 (direct join): SELECT permits.*, tokens.address, tokens.network, partners.wallet.address, locations.node_url FROM permits INNER JOIN users ON permits.beneficiary_id = users.id INNER JOIN wallets ON users.wallet_id = wallets.id WHERE wallets.address ILIKE '${normalizedWalletAddress}' AND permits.transaction IS NULL`);
+  console.log(
+    `Worker: SQL Query 2 (direct join): SELECT permits.*, tokens.address, tokens.network, partners.wallet.address, locations.node_url FROM permits INNER JOIN users ON permits.beneficiary_id = users.id INNER JOIN wallets ON users.wallet_id = wallets.id WHERE wallets.address ILIKE '${normalizedWalletAddress}' AND permits.transaction IS NULL`
+  );
 
-        let query = supabase.from(PERMITS_TABLE)
-            .select(directJoinQuery)
-            .is("transaction", null);
+  let query = supabase.from(PERMITS_TABLE).select(directJoinQuery).is("transaction", null).filter("users.wallets.address", "ilike", normalizedWalletAddress);
 
-        // Add filter for wallets.address through the join path
-        // Note: This is a simplification - the actual query construction in Supabase is more complex
-        query = query.filter('users.wallets.address', 'ilike', normalizedWalletAddress);
+  if (lastCheckTimestamp && !isNaN(Date.parse(lastCheckTimestamp))) {
+    query = query.gt("created", lastCheckTimestamp);
+  }
 
-        if (lastCheckTimestamp && !isNaN(Date.parse(lastCheckTimestamp))) {
-            query = query.gt('created', lastCheckTimestamp);
-        }
+  const result = await query;
 
-        const result = await query;
+  if (result.error) {
+    console.error(`Worker: query error: ${result.error.message}`, result.error);
+  } else if (result.data && result.data.length > 0) {
+    console.log(`Worker: Found ${result.data.length} permits using direct join approach`);
+    permitsData = result.data;
+  } else {
+    console.log(`Worker: No permits found`);
+  }
 
-        if (result.error) {
-            console.error(`Worker: Direct join query error: ${result.error.message}`, result.error);
-        } else if (result.data && result.data.length > 0) {
-            console.log(`Worker: Found ${result.data.length} permits using direct join approach`);
-            permitsData = result.data;
-        } else {
-            console.log(`Worker: No permits found using direct join approach`);
-        }
-    }
+  if (permitsData.length === 0) {
+    console.log(`Worker: No permits found for wallet address: ${normalizedWalletAddress}`);
+    return [];
+  }
 
-    // APPROACH 3: Fallback - Query all permits and filter client-side
-    if (permitsData.length === 0 && !permitError) {
-        console.log(`Worker: APPROACH 3 - Fallback: Query all permits and filter client-side`);
+  console.log(`Worker: Successfully found ${permitsData.length} permits for wallet address: ${normalizedWalletAddress}`);
 
-        // This is a last resort - query all permits and look for any that might be related to our wallet
-        let query = supabase.from(PERMITS_TABLE)
-            .select(`*, created, token: ${TOKENS_TABLE} (address, network), partner: ${PARTNERS_TABLE} (wallet: ${WALLETS_TABLE} (address)), location: ${LOCATIONS_TABLE} (node_url)`)
-            .is("transaction", null)
-            .limit(100); // Limit to avoid fetching too many records
-
-        if (lastCheckTimestamp && !isNaN(Date.parse(lastCheckTimestamp))) {
-            query = query.gt('created', lastCheckTimestamp);
-        }
-
-        console.log(`Worker: SQL Query 3 (fallback): SELECT * FROM ${PERMITS_TABLE} WHERE transaction IS NULL LIMIT 100`);
-
-        const result = await query;
-
-        if (result.error) {
-            console.error(`Worker: Fallback query error: ${result.error.message}`, result.error);
-        } else if (result.data && result.data.length > 0) {
-            console.log(`Worker: Found ${result.data.length} permits in fallback query, will filter client-side`);
-
-            // Log all permits for debugging
-            console.log(`Worker: All permits from fallback query:`, JSON.stringify(result.data.slice(0, 5) + (result.data.length > 5 ? ` ... and ${result.data.length - 5} more` : '')));
-
-            // Filter permits that might be related to our wallet address
-            // This is a loose filter that looks for the wallet address in any field
-            const filteredPermits = result.data.filter(permit => {
-                // Check if the wallet address appears in any relevant field
-                const ownerAddress = permit.partner?.wallet?.address?.toLowerCase();
-                const beneficiaryMatches = permit.beneficiary_id && String(permit.beneficiary_id).includes(normalizedWalletAddress);
-                const ownerMatches = ownerAddress && ownerAddress === normalizedWalletAddress;
-
-                return beneficiaryMatches || ownerMatches;
-            });
-
-            if (filteredPermits.length > 0) {
-                console.log(`Worker: Found ${filteredPermits.length} permits related to wallet ${normalizedWalletAddress} in fallback query`);
-                permitsData = filteredPermits;
-            } else {
-                console.log(`Worker: No permits related to wallet ${normalizedWalletAddress} found in fallback query`);
-            }
-        } else {
-            console.log(`Worker: No permits found in fallback query`);
-        }
-    }
-
-    // APPROACH 4: Last resort - Query raw permits table
-    if (permitsData.length === 0 && !permitError) {
-        console.log(`Worker: APPROACH 4 - Last resort: Query raw permits table`);
-
-        // Direct SQL query to check if there are any permits at all
-        const { data: allPermits, error: allPermitsError } = await supabase
-            .from(PERMITS_TABLE)
-            .select('id, nonce, beneficiary_id')
-            .limit(5);
-
-        if (allPermitsError) {
-            console.error(`Worker: Error querying raw permits: ${allPermitsError.message}`);
-        } else {
-            console.log(`Worker: Sample of raw permits in database:`, JSON.stringify(allPermits));
-        }
-
-        // Query wallets table directly to check if the wallet exists
-        const { data: walletCheck, error: walletCheckError } = await supabase
-            .from('wallets')
-            .select('id, address')
-            .limit(10);
-
-        if (walletCheckError) {
-            console.error(`Worker: Error querying wallets: ${walletCheckError.message}`);
-        } else {
-            console.log(`Worker: Sample of wallets in database:`, JSON.stringify(walletCheck));
-        }
-    }
-
-    if (permitsData.length === 0) {
-        console.log(`Worker: No permits found for wallet address: ${normalizedWalletAddress} after trying all approaches`);
-        return [];
-    }
-
-    console.log(`Worker: Successfully found ${permitsData.length} permits for wallet address: ${normalizedWalletAddress}`);
-
-    // Cast needed because Supabase client doesn't know about the joined types automatically
-    return permitsData as unknown as PermitRow[];
+  // Cast needed because Supabase client doesn't know about the joined types automatically
+  return permitsData as unknown as PermitRow[];
 }
 
 // --- On-Chain Validation ---
 
-// Function to perform batch validation using rpcClient
-async function validatePermitsBatch(permitsToValidate: PermitData[]): Promise<PermitData[]> {
-    if (!rpcClient) throw new Error("RPC client not initialized.");
-    if (permitsToValidate.length === 0) {
-        // console.log("Worker: No permits provided for validation.");
-        return [];
-    }
-
-    const checkedPermitsMap = new Map<string, Partial<PermitData & { isNonceUsed?: boolean }>>();
-    const batchRequests: { request: JsonRpcRequest; key: string; type: string; requiredAmount?: bigint; chainId: number }[] = [];
-    let requestIdCounter = 1;
-    const permitsByKey = new Map<string, PermitData>(permitsToValidate.map(p => [`${p.nonce}-${p.networkId}`, p]));
-
-    permitsToValidate.forEach((permit) => {
-        // Only handle ERC20 permits as per simplified logic
-        if (permit.type !== 'erc20-permit') {
-            console.warn(`Worker: Skipping validation for non-ERC20 permit: ${permit.nonce}`);
-            return;
-        };
-
-        const key = `${permit.nonce}-${permit.networkId}`;
-        const chainId = permit.networkId;
-        const owner = permit.owner as Address;
-
-        // Nonce Check (ERC20 only)
-        const wordPos = BigInt(permit.nonce) >> 8n;
-        batchRequests.push({
-            request: { jsonrpc: '2.0', method: 'eth_call', params: [{ to: "0x000000000022D473030F116dDEE9F6B43aC78BA3", data: encodeFunctionData({ abi: [permit2Abi], functionName: "nonceBitmap", args: [owner, wordPos] }) }, 'latest'], id: requestIdCounter++ },
-            key, type: "nonce", chainId
-        });
-
-        // Balance & Allowance Checks
-        if (permit.token?.address && permit.amount && permit.owner) {
-            const calls = preparePermitPrerequisiteContracts(permit);
-            if (calls) {
-                const requiredAmount = BigInt(permit.amount);
-                const [balanceCall, allowanceCall] = calls;
-                batchRequests.push({
-                    request: { jsonrpc: '2.0', method: 'eth_call', params: [{ to: balanceCall.address, data: encodeFunctionData({ abi: balanceCall.abi as Abi, functionName: balanceCall.functionName, args: balanceCall.args }) }, 'latest'], id: requestIdCounter++ },
-                    key, type: "balance", requiredAmount, chainId
-                });
-                batchRequests.push({
-                    request: { jsonrpc: '2.0', method: 'eth_call', params: [{ to: allowanceCall.address, data: encodeFunctionData({ abi: allowanceCall.abi as Abi, functionName: allowanceCall.functionName, args: allowanceCall.args }) }, 'latest'], id: requestIdCounter++ },
-                    key, type: "allowance", requiredAmount, chainId
-                });
-            }
-        } else {
-             console.warn(`Worker: Skipping balance/allowance check for permit ${key} due to missing data.`);
-        }
-    });
-
-    // console.log(`Worker: Sending validation batch request with ${batchRequests.length} checks.`);
-    if (batchRequests.length === 0) return permitsToValidate; // Return original if nothing to check (e.g., only non-ERC20 passed)
-
-    try {
-        const batchPayload = batchRequests.map(br => br.request);
-        // Assuming chainId 100 for all permits currently
-        const batchResponses = await rpcClient.request(100, batchPayload) as JsonRpcResponse[];
-        // console.log(`Worker: Received ${batchResponses.length} validation responses in batch.`);
-
-        const responseMap = new Map<number, JsonRpcResponse>(batchResponses.map(res => [res.id as number, res]));
-
-        batchRequests.forEach(batchReq => {
-            const permit = permitsByKey.get(batchReq.key);
-            if (!permit) return;
-
-            const res = responseMap.get(batchReq.request.id as number);
-            // Initialize updateData with existing permit data to preserve fields not checked
-            const updateData: Partial<PermitData & { isNonceUsed?: boolean }> = checkedPermitsMap.get(batchReq.key) || {};
-
-
-            if (!res) {
-                updateData.checkError = `Batch response missing (${batchReq.type})`;
-            } else if (res.error) {
-                updateData.checkError = `Check failed (${batchReq.type}). ${res.error.message}`;
-            } else if (res.result !== undefined && res.result !== null) {
-                try {
-                    if (batchReq.type === "balance" && batchReq.requiredAmount !== undefined) updateData.ownerBalanceSufficient = BigInt(res.result as string) >= batchReq.requiredAmount;
-                    else if (batchReq.type === "allowance" && batchReq.requiredAmount !== undefined) updateData.permit2AllowanceSufficient = BigInt(res.result as string) >= batchReq.requiredAmount;
-                    else if (batchReq.type === "nonce") {
-                        const bitmap = BigInt(res.result as string);
-                        updateData.isNonceUsed = Boolean(bitmap & (1n << (BigInt(permit.nonce) & 255n)));
-                    }
-                    // Clear checkError if this specific check succeeded
-                    if (updateData.checkError?.includes(`(${batchReq.type})`)) {
-                        updateData.checkError = undefined;
-                    }
-                } catch (parseError: unknown) {
-                    updateData.checkError = `Result parse error (${batchReq.type}). ${parseError instanceof Error ? parseError.message : String(parseError)}`;
-                }
-            } else {
-                updateData.checkError = `Empty result (${batchReq.type})`;
-            }
-            checkedPermitsMap.set(batchReq.key, updateData);
-        });
-
-    } catch (error: unknown) {
-        console.error("Worker: Error during validation batch RPC request:", error);
-        // Mark all permits in this validation batch as errored
-        permitsToValidate.forEach(permit => {
-             const key = `${permit.nonce}-${permit.networkId}`;
-             const updateData = checkedPermitsMap.get(key) || { checkError: `Batch request failed: ${error instanceof Error ? error.message : String(error)}` };
-             if (!updateData.checkError) { // Don't overwrite specific check errors
-                 updateData.checkError = `Batch request failed: ${error instanceof Error ? error.message : String(error)}`;
-             }
-             checkedPermitsMap.set(key, updateData);
-        });
-    }
-
-    // Map results back onto the original permits passed in
-    return permitsToValidate.map(permit => {
-        const key = `${permit.nonce}-${permit.networkId}`;
-        const checkData = checkedPermitsMap.get(key);
-        // Merge validation results onto the permit data
-        return checkData ? { ...permit, ...checkData } : permit;
-    });
+async function getPermit2Address(permitData: PermitData) {
+  const permit: PermitTransferFrom = {
+    permitted: {
+      token: permitData.tokenAddress as Address,
+      amount: BigInt(permitData.amount ?? 0),
+    },
+    nonce: BigInt(permitData.nonce),
+    deadline: BigInt(permitData.deadline),
+    spender: permitData.beneficiary as Address,
+  };
+  const hash = SignatureTransfer.hash(permit, NEW_PERMIT2_ADDRESS, permitData.networkId) as `0x${string}`;
+  const signer = await recoverAddress({ hash, signature: permitData.signature as `0x${string}` });
+  if (signer.toLowerCase() === permitData.owner.toLowerCase()) {
+    return NEW_PERMIT2_ADDRESS;
+  }
+  // If the signer doesn't match, fallback to old permit address
+  console.warn(`Worker: Permit ${permitData.signature} signer mismatch. Using old permit address.`);
+  return OLD_PERMIT2_ADDRESS;
 }
 
+// Function to perform batch validation using rpcClient
+async function validatePermitsBatch(permitsToValidate: PermitData[]): Promise<PermitData[]> {
+  if (!rpcClient) throw new Error("RPC client not initialized.");
+  if (permitsToValidate.length === 0) {
+    // console.log("Worker: No permits provided for validation.");
+    return [];
+  }
+
+  await Promise.all(
+    permitsToValidate.map(async (permit) => {
+      permit.permit2Address = await getPermit2Address(permit);
+    })
+  );
+
+  const checkedPermitsMap = new Map<string, Partial<PermitData & { isNonceUsed?: boolean }>>();
+  const batchRequests: { request: JsonRpcRequest; key: string; type: string; requiredAmount?: bigint; chainId: number }[] = [];
+  let requestIdCounter = 1;
+  const permitsByKey = new Map<string, PermitData>(permitsToValidate.map((p) => [p.signature, p]));
+
+  permitsToValidate.forEach((permit) => {
+    // Only handle ERC20 permits as per simplified logic
+    if (permit.type !== "erc20-permit") {
+      console.warn(`Worker: Skipping validation for non-ERC20 permit: ${permit.nonce}`);
+      return;
+    }
+
+    const key = permit.signature;
+    const chainId = permit.networkId;
+    const owner = permit.owner as Address;
+
+    // Nonce Check (ERC20 only)
+    const wordPos = BigInt(permit.nonce) >> 8n;
+    batchRequests.push({
+      request: {
+        jsonrpc: "2.0",
+        method: "eth_call",
+        params: [{ to: permit.permit2Address, data: encodeFunctionData({ abi: [permit2Abi], functionName: "nonceBitmap", args: [owner, wordPos] }) }, "latest"],
+        id: requestIdCounter++,
+      },
+      key,
+      type: "nonce",
+      chainId,
+    });
+
+    // Balance & Allowance Checks
+    if (permit.token?.address && permit.amount && permit.owner) {
+      const calls = preparePermitPrerequisiteContracts(permit);
+      if (calls) {
+        const requiredAmount = BigInt(permit.amount);
+        const [balanceCall, allowanceCall] = calls;
+        batchRequests.push({
+          request: {
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: [
+              {
+                to: balanceCall.address,
+                data: encodeFunctionData({ abi: balanceCall.abi as Abi, functionName: balanceCall.functionName, args: balanceCall.args }),
+              },
+              "latest",
+            ],
+            id: requestIdCounter++,
+          },
+          key,
+          type: "balance",
+          requiredAmount,
+          chainId,
+        });
+        batchRequests.push({
+          request: {
+            jsonrpc: "2.0",
+            method: "eth_call",
+            params: [
+              {
+                to: allowanceCall.address,
+                data: encodeFunctionData({ abi: allowanceCall.abi as Abi, functionName: allowanceCall.functionName, args: allowanceCall.args }),
+              },
+              "latest",
+            ],
+            id: requestIdCounter++,
+          },
+          key,
+          type: "allowance",
+          requiredAmount,
+          chainId,
+        });
+      }
+    } else {
+      console.warn(`Worker: Skipping balance/allowance check for permit ${key} due to missing data.`);
+    }
+  });
+
+  // console.log(`Worker: Sending validation batch request with ${batchRequests.length} checks.`);
+  if (batchRequests.length === 0) return permitsToValidate; // Return original if nothing to check (e.g., only non-ERC20 passed)
+
+  try {
+    const batchPayload = batchRequests.map((br) => br.request);
+    // Assuming same chainId for all permits currently
+    const batchResponses = (await rpcClient.request(batchRequests[0].chainId, batchPayload)) as JsonRpcResponse[];
+    // console.log(`Worker: Received ${batchResponses.length} validation responses in batch.`);
+
+    const responseMap = new Map<number, JsonRpcResponse>(batchResponses.map((res) => [res.id as number, res]));
+
+    batchRequests.forEach((batchReq) => {
+      const permit = permitsByKey.get(batchReq.key);
+      if (!permit) return;
+
+      const res = responseMap.get(batchReq.request.id as number);
+      // Initialize updateData with existing permit data to preserve fields not checked
+      const updateData: Partial<PermitData & { isNonceUsed?: boolean }> = checkedPermitsMap.get(batchReq.key) || {};
+
+      if (!res) {
+        updateData.checkError = `Batch response missing (${batchReq.type})`;
+      } else if (res.error) {
+        updateData.checkError = `Check failed (${batchReq.type}). ${res.error.message}`;
+      } else if (res.result !== undefined && res.result !== null) {
+        try {
+          if (batchReq.type === "balance" && batchReq.requiredAmount !== undefined)
+            updateData.ownerBalanceSufficient = BigInt(res.result as string) >= batchReq.requiredAmount;
+          else if (batchReq.type === "allowance" && batchReq.requiredAmount !== undefined)
+            updateData.permit2AllowanceSufficient = BigInt(res.result as string) >= batchReq.requiredAmount;
+          else if (batchReq.type === "nonce") {
+            const bitmap = BigInt(res.result as string);
+            updateData.isNonceUsed = Boolean(bitmap & (1n << (BigInt(permit.nonce) & 255n)));
+            updateData.status = updateData.isNonceUsed ? "Claimed" : "Valid";
+          }
+          // Clear checkError if this specific check succeeded
+          if (updateData.checkError?.includes(`(${batchReq.type})`)) {
+            updateData.checkError = undefined;
+          }
+        } catch (parseError: unknown) {
+          updateData.checkError = `Result parse error (${batchReq.type}). ${parseError instanceof Error ? parseError.message : String(parseError)}`;
+        }
+      } else {
+        updateData.checkError = `Empty result (${batchReq.type})`;
+      }
+      checkedPermitsMap.set(batchReq.key, updateData);
+    });
+  } catch (error: unknown) {
+    console.error("Worker: Error during validation batch RPC request:", error);
+    // Mark all permits in this validation batch as errored
+    permitsToValidate.forEach((permit) => {
+      const updateData = checkedPermitsMap.get(permit.signature) || {
+        checkError: `Batch request failed: ${error instanceof Error ? error.message : String(error)}`,
+      };
+      if (!updateData.checkError) {
+        // Don't overwrite specific check errors
+        updateData.checkError = `Batch request failed: ${error instanceof Error ? error.message : String(error)}`;
+      }
+      checkedPermitsMap.set(permit.signature, updateData);
+    });
+  }
+
+  // Enrich permits with validation data by signature and dedupe by nonce
+  const finalPermits = permitsToValidate.map((permit) => {
+    const checkData = checkedPermitsMap.get(permit.signature);
+    return checkData ? { ...permit, ...checkData } : permit;
+  });
+
+  const permitsByNonce = finalPermits.reduce((map, p) => {
+    const list = map.get(p.nonce) || [];
+    list.push(p);
+    map.set(p.nonce, list);
+    return map;
+  }, new Map<string, PermitData[]>());
+
+  // check duplicated permits by nonce
+  for (const nonceGroup of permitsByNonce.values()) {
+    const sortedByAmountDescending = nonceGroup.slice().sort((a, b) => {
+      const diff = BigInt(b.amount || "0") - BigInt(a.amount || "0");
+      return diff > 0n ? 1 : diff < 0n ? -1 : 0;
+    });
+    const passing = sortedByAmountDescending.find((p) => !p.checkError); // find the permit with highest amount and no error
+    if (passing) {
+      nonceGroup.forEach((p) => {
+        if (!p.checkError && p.signature !== passing.signature) {
+          p.checkError = "permit with same nonce but higher amount exists";
+        }
+      });
+    }
+  }
+
+  // set status to "Valid" for permits that passed all checks
+  finalPermits.forEach((p) => {
+    if (!p.checkError && p.status === undefined) {
+      p.status = "Valid";
+    }
+  });
+
+  return finalPermits;
+}
 
 // --- Worker Message Handling ---
 
-worker.onmessage = async (event: MessageEvent<{ type: 'INIT' | 'FETCH_NEW_PERMITS' | 'VALIDATE_PERMITS'; payload: WorkerPayload }>) => {
-    const { type, payload } = event.data;
+worker.onmessage = async (event: MessageEvent<{ type: "INIT" | "FETCH_NEW_PERMITS" | "VALIDATE_PERMITS"; payload: WorkerPayload }>) => {
+  const { type, payload } = event.data;
 
-    if (type === 'INIT') {
-        const supabaseUrl = payload.supabaseUrl;
-        const supabaseAnonKey = payload.supabaseAnonKey;
-        // Use VITE_RPC_URL from .env (see .env.example), or default to https://rpc.ubq.fi
-        PROXY_BASE_URL = payload.proxyBaseUrl || import.meta.env.VITE_RPC_URL || "https://rpc.ubq.fi";
+  if (type === "INIT") {
+    const supabaseUrl = payload.supabaseUrl;
+    const supabaseAnonKey = payload.supabaseAnonKey;
+    // Use VITE_RPC_URL from .env (see .env.example), or default to https://rpc.ubq.fi
+    PROXY_BASE_URL = payload.proxyBaseUrl || import.meta.env.VITE_RPC_URL || "https://rpc.ubq.fi";
 
-        if (supabaseUrl && supabaseAnonKey) {
-            try {
-                supabase = createClient<Database>(supabaseUrl, supabaseAnonKey); // Use Database type
-                rpcClient = createRpcClient({ baseUrl: PROXY_BASE_URL }); // Init RPC client here
-                // console.log("Worker: Supabase and RPC clients initialized.");
-                worker.postMessage({ type: 'INIT_SUCCESS' });
-            } catch (error: unknown) {
-                console.error("Worker: Error initializing clients:", error);
-                worker.postMessage({ type: 'INIT_ERROR', error: error instanceof Error ? error.message : String(error) });
-            }
-        } else {
-            worker.postMessage({ type: 'INIT_ERROR', error: 'Supabase/RPC credentials not received by worker.' });
-        }
-    } else if (type === 'FETCH_NEW_PERMITS') {
-        const address = payload.address as Address;
-        const lastCheckTimestamp = payload.lastCheckTimestamp;
-        // console.log(`Worker: Received FETCH_NEW_PERMITS for ${address}`);
-        try {
-            if (!supabase) throw new Error("Supabase client not ready.");
-            const lowerCaseWalletAddress = address.toLowerCase();
-
-            console.log(`Worker: Fetching permits for wallet address: ${lowerCaseWalletAddress}`);
-
-            // Fetch *only new* permits from DB using the wallet address and timestamp
-            const newPermitsFromDb = await fetchPermitsFromDb(lowerCaseWalletAddress, lastCheckTimestamp ?? null);
-
-            // 3. Map and pre-filter *new* permits
-            // Add explicit types to map parameters
-            const mappedNewPermits = newPermitsFromDb.map((p: PermitRow, i: number) => mapDbPermitToPermitData(p, i, lowerCaseWalletAddress)).filter((p): p is PermitData => p !== null);
-            console.log(`Worker: Mapped ${mappedNewPermits.length} new permits for wallet address: ${lowerCaseWalletAddress}`);
-
-            // 4. Validate *only* the mapped new permits
-            if (mappedNewPermits.length > 0) {
-                const validatedNewPermits = await validatePermitsBatch(mappedNewPermits);
-                worker.postMessage({ type: 'NEW_PERMITS_VALIDATED', permits: validatedNewPermits });
-            } else {
-                // If no new permits were found, still send back an empty array for consistency
-                worker.postMessage({ type: 'NEW_PERMITS_VALIDATED', permits: [] });
-            }
-
-        } catch (error: unknown) {
-            console.error("Worker: Error fetching/validating new permits:", error);
-            worker.postMessage({ type: 'PERMITS_ERROR', error: error instanceof Error ? error.message : String(error) });
-        }
-    } else if (type === 'VALIDATE_PERMITS') { // This message type might become obsolete with the new flow, but keep for now? Or remove? Let's remove for now.
-       // This case is handled internally now after fetching new permits.
-       console.warn("Worker: Received unexpected VALIDATE_PERMITS message.");
-       // Optionally handle if needed, otherwise ignore.
+    if (supabaseUrl && supabaseAnonKey) {
+      try {
+        supabase = createClient<Database>(supabaseUrl, supabaseAnonKey); // Use Database type
+        rpcClient = createRpcClient({ baseUrl: PROXY_BASE_URL }); // Init RPC client here
+        // console.log("Worker: Supabase and RPC clients initialized.");
+        worker.postMessage({ type: "INIT_SUCCESS" });
+      } catch (error: unknown) {
+        console.error("Worker: Error initializing clients:", error);
+        worker.postMessage({ type: "INIT_ERROR", error: error instanceof Error ? error.message : String(error) });
+      }
+    } else {
+      worker.postMessage({ type: "INIT_ERROR", error: "Supabase/RPC credentials not received by worker." });
     }
+  } else if (type === "FETCH_NEW_PERMITS") {
+    const address = payload.address as Address;
+    const lastCheckTimestamp = payload.lastCheckTimestamp;
+    // console.log(`Worker: Received FETCH_NEW_PERMITS for ${address}`);
+    try {
+      if (!supabase) throw new Error("Supabase client not ready.");
+      const lowerCaseWalletAddress = address.toLowerCase();
+
+      console.log(`Worker: Fetching permits for wallet address: ${lowerCaseWalletAddress}`);
+
+      // Fetch *only new* permits from DB using the wallet address and timestamp
+      const newPermitsFromDb = await fetchPermitsFromDb(lowerCaseWalletAddress, lastCheckTimestamp ?? null);
+
+      // 3. Map and pre-filter *new* permits
+      // Add explicit types to map parameters
+      const mappedNewPermits = newPermitsFromDb
+        .map((p: PermitRow, i: number) => mapDbPermitToPermitData(p, i, lowerCaseWalletAddress))
+        .filter((p): p is PermitData => p !== null);
+      console.log(`Worker: Mapped ${mappedNewPermits.length} new permits for wallet address: ${lowerCaseWalletAddress}`);
+
+      // 4. Validate *only* the mapped new permits
+      if (mappedNewPermits.length > 0) {
+        const validatedNewPermits = await validatePermitsBatch(mappedNewPermits);
+        worker.postMessage({ type: "NEW_PERMITS_VALIDATED", permits: validatedNewPermits });
+      } else {
+        // If no new permits were found, still send back an empty array for consistency
+        worker.postMessage({ type: "NEW_PERMITS_VALIDATED", permits: [] });
+      }
+    } catch (error: unknown) {
+      console.error("Worker: Error fetching/validating new permits:", error);
+      worker.postMessage({ type: "PERMITS_ERROR", error: error instanceof Error ? error.message : String(error) });
+    }
+  } else if (type === "VALIDATE_PERMITS") {
+    // This message type might become obsolete with the new flow, but keep for now? Or remove? Let's remove for now.
+    // This case is handled internally now after fetching new permits.
+    console.warn("Worker: Received unexpected VALIDATE_PERMITS message.");
+    // Optionally handle if needed, otherwise ignore.
+  }
 };
 
 // console.log("Permit checker worker started.");


### PR DESCRIPTION

Improvements:
- now permits are indexed/referenced by the signature instead of `nonce-networkId` because it's the signature is truly unique and nonce can be the same if two permits are generated in the same issue
- if there are 2 permits with the same nonce, only use the one with the higher amount
- removed multiple ways of fetching from DB because they are all the same, the only difference was whether the filter was done DB-side or client-side

`transaction` column needs unique constraint removed because of batch claim